### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: Go CI
+
+on:
+  push:
+    branches:
+      - '*'
+  create:
+    tags:
+      - 'v*' # Trigger on tags like v1.0, v0.1.0, etc.
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.2'
+
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+
+      - name: Run golangci-lint
+        run: $(go env GOPATH)/bin/golangci-lint run ./...
+
+  build-release:
+    name: Build and Release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') # Only run for tags starting with 'v'
+    needs: lint # Ensure linting passes before building
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22.2'
+
+      - name: Build for Linux (amd64)
+        run: |
+          GOOS=linux GOARCH=amd64 go build -o file-editor-linux-amd64 ./cmd/file-editor
+          echo "Built file-editor-linux-amd64"
+
+      - name: Build for macOS (amd64)
+        run: |
+          GOOS=darwin GOARCH=amd64 go build -o file-editor-darwin-amd64 ./cmd/file-editor
+          echo "Built file-editor-darwin-amd64"
+
+      - name: Create Release and Upload Assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            file-editor-linux-amd64
+            file-editor-darwin-amd64
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow introduces CI capabilities to the project:

1.  **Linting on Pull Requests:**
    *   Triggers on every push to any branch that is part of a pull request.
    *   Uses `golangci-lint` to lint the Go codebase.
    *   Ensures code quality before merging.

2.  **Release Binary Builds on New Tags:**
    *   Triggers when a new tag starting with 'v' (e.g., v1.0.0, v0.1.2) is pushed.
    *   Depends on the linting job passing.
    *   Builds executable binaries for:
        *   Linux (amd64)
        *   macOS (amd64)
    *   Creates a GitHub Release corresponding to the tag.
    *   Uploads the compiled binaries as assets to the release.

The Go version is pinned to 1.22.2 based on the go.mod file. The main application package is assumed to be `cmd/file-editor/`.