### PR TITLE
Update Go to 1.24.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.2'
+          go-version: '1.24.4'
 
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.2'
+          go-version: '1.24.4'
 
       - name: Build for Linux (amd64)
         run: |

--- a/cmd/file-editor/main.go
+++ b/cmd/file-editor/main.go
@@ -68,7 +68,8 @@ func main() {
 	}()
 
 	// 6. Initialize and Start Transport
-	if cfg.Transport == "http" {
+	switch cfg.Transport {
+	case "http":
 		log.Printf("Initializing HTTP transport on port %d...\n", cfg.Port)
 		// Note: MaxFileSizeMB is a placeholder for the second arg of NewHTTPHandler,
 		// as it currently uses a hardcoded 50MB for HTTP request size.
@@ -116,7 +117,7 @@ func main() {
 			}
 		}()
 
-	} else if cfg.Transport == "stdio" {
+	case "stdio":
 		log.Println("Initializing STDIN/STDOUT JSON-RPC transport...")
 		go func() {
 			stdioHandler := transport.NewStdioHandler(fileService)
@@ -127,7 +128,7 @@ func main() {
 				serverDoneChan <- nil // Stdio handler finished (e.g. EOF)
 			}
 		}()
-	} else {
+	default:
 		log.Printf("CRITICAL: Unsupported transport type: %s\n", cfg.Transport)
 		os.Exit(1) // Should be caught by config validation, but defensive
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module file-editor-server
 
-go 1.22.2
+go 1.24.4

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -16,19 +16,19 @@ import (
 
 // --- Mock FileSystemAdapter ---
 type mockFileSystemAdapter struct {
-	files                map[string][]byte
-	stats                map[string]*filesystem.FileStats
-	existsShouldFail     bool
-	readShouldFail       bool
-	writeShouldFail      bool
-	statsShouldFail      bool
-	isWritableResult     bool
-	isWritableShouldFail bool
-	isValidUTF8Result    bool
-	listDirShouldFail    bool
-	listDirEntries       map[string][]filesystem.DirEntryInfo
-	readFileErrorForPath map[string]error
-	isInvalidUTF8Content map[string]bool
+	files                    map[string][]byte
+	stats                    map[string]*filesystem.FileStats
+	existsShouldFail         bool
+	readShouldFail           bool
+	writeShouldFail          bool
+	statsShouldFail          bool
+	isWritableResult         bool
+	isWritableShouldFail     bool
+	isValidUTF8Result        bool
+	listDirShouldFail        bool
+	listDirEntries           map[string][]filesystem.DirEntryInfo
+	readFileErrorForPath     map[string]error
+	isInvalidUTF8Content     map[string]bool
 	evalSymlinksPaths        map[string]string
 	evalSymlinksErrorForPath map[string]error
 	// Add more controls as needed
@@ -251,7 +251,9 @@ func setup(t *testing.T) (*DefaultFileOperationService, *mockFileSystemAdapter, 
 
 func cleanup(t *testing.T) {
 	if tempWorkingDir != "" {
-		os.RemoveAll(tempWorkingDir)
+		if err := os.RemoveAll(tempWorkingDir); err != nil {
+			t.Fatalf("failed to remove temp dir: %v", err)
+		}
 	}
 }
 

--- a/internal/transport/http.go
+++ b/internal/transport/http.go
@@ -99,7 +99,9 @@ func (h *HTTPHandler) handleReadFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	r.Body = http.MaxBytesReader(w, r.Body, h.maxReqSize)
-	defer r.Body.Close()
+	defer func() {
+		_ = r.Body.Close()
+	}()
 
 	var req models.ReadFileRequest
 	decoder := json.NewDecoder(r.Body)
@@ -154,7 +156,9 @@ func (h *HTTPHandler) handleEditFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	r.Body = http.MaxBytesReader(w, r.Body, h.maxReqSize)
-	defer r.Body.Close()
+	defer func() {
+		_ = r.Body.Close()
+	}()
 
 	var req models.EditFileRequest
 	decoder := json.NewDecoder(r.Body)
@@ -250,7 +254,9 @@ func (h *HTTPHandler) handleListFiles(w http.ResponseWriter, r *http.Request) {
 	if r.ContentLength > 0 {
 		// MaxBytesReader to prevent large empty bodies if someone sends one.
 		r.Body = http.MaxBytesReader(w, r.Body, 1024) // Limit empty body to 1KB
-		defer r.Body.Close()
+		defer func() {
+			_ = r.Body.Close()
+		}()
 
 		decoder := json.NewDecoder(r.Body)
 		decoder.DisallowUnknownFields()

--- a/internal/transport/http_test.go
+++ b/internal/transport/http_test.go
@@ -64,7 +64,9 @@ func TestHTTPHandler_handleReadFile_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected status %d, got %d", http.StatusOK, resp.StatusCode)
@@ -94,7 +96,9 @@ func TestHTTPHandler_handleReadFile_ServiceError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	// File not found -> maps to 404
 	expectedStatus := http.StatusNotFound
@@ -121,7 +125,9 @@ func TestHTTPHandler_handleReadFile_InvalidJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected status %d, got %d", http.StatusBadRequest, resp.StatusCode)
@@ -146,7 +152,9 @@ func TestHTTPHandler_handleReadFile_BodyTooLarge(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusRequestEntityTooLarge {
 		t.Errorf("expected status %d, got %d", http.StatusRequestEntityTooLarge, resp.StatusCode)
@@ -175,7 +183,9 @@ func TestHTTPHandler_handleReadFile_WrongMethod(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusMethodNotAllowed {
 		t.Errorf("expected status %d, got %d", http.StatusMethodNotAllowed, resp.StatusCode)
@@ -200,7 +210,9 @@ func TestHTTPHandler_handleEditFile_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected status %d, got %d", http.StatusOK, resp.StatusCode)
@@ -229,7 +241,9 @@ func TestHTTPHandler_handleEditFile_ServiceError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusBadRequest { // InvalidParams maps to 400
 		t.Errorf("expected status %d, got %d", http.StatusBadRequest, resp.StatusCode)
@@ -252,7 +266,9 @@ func TestHTTPHandler_HealthCheck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET request to /health failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected status %d for /health, got %d", http.StatusOK, resp.StatusCode)
@@ -335,7 +351,9 @@ func TestHTTPHandler_handleReadFile_DisallowUnknownFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("POST request failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusBadRequest { // Expecting bad request due to unknown field
 		bodyBytes, _ := io.ReadAll(resp.Body)


### PR DESCRIPTION
## Summary
- bump Go toolchain version to 1.24.4
- update CI workflow to use Go 1.24.4
- handle errcheck warnings in filesystem adapter and tests
- ensure `r.Body.Close()` errors are ignored explicitly
- replace transport selection `if` chain with a `switch`

## Testing
- `go test ./...` *(fails: go.mod requires go >= 1.24.4)*
- `golangci-lint run ./...` *(fails: go.mod requires go >= 1.24.4)*

------
https://chatgpt.com/codex/tasks/task_e_6841fa59d9b08332aa1a15e8178f56ac