### PR TITLE
Remove directory from list responses

### DIFF
--- a/internal/mcp/processor.go
+++ b/internal/mcp/processor.go
@@ -81,7 +81,7 @@ func (p *MCPProcessor) handleToolCall(toolName string, toolArgs json.RawMessage)
 				Message: "Invalid parameters for list_files: " + err.Error(),
 			}
 		}
-		files, dir, serviceErr := p.service.ListFiles(listParams)
+		files, serviceErr := p.service.ListFiles(listParams)
 		if serviceErr != nil {
 			return &models.MCPToolResult{
 				Content: []models.MCPToolContent{{Type: "text", Text: p.formatToolError(serviceErr)}},
@@ -89,7 +89,7 @@ func (p *MCPProcessor) handleToolCall(toolName string, toolArgs json.RawMessage)
 			}, nil
 		}
 		return &models.MCPToolResult{
-			Content: []models.MCPToolContent{{Type: "text", Text: p.formatListFilesResult(files, dir)}},
+			Content: []models.MCPToolContent{{Type: "text", Text: p.formatListFilesResult(files)}},
 			IsError: false,
 		}, nil
 	case "read_file":
@@ -139,12 +139,12 @@ func (p *MCPProcessor) handleToolCall(toolName string, toolArgs json.RawMessage)
 }
 
 // formatListFilesResult formats the result of a list_files call.
-func (p *MCPProcessor) formatListFilesResult(files []models.FileInfo, directory string) string {
+func (p *MCPProcessor) formatListFilesResult(files []models.FileInfo) string {
 	if len(files) == 0 {
-		return fmt.Sprintf("No files found in directory: %s", directory)
+		return "No files found"
 	}
 	var builder strings.Builder
-	builder.WriteString(fmt.Sprintf("Directory: %s\nTotal files: %d\n\n", directory, len(files)))
+	builder.WriteString(fmt.Sprintf("Total files: %d\n\n", len(files)))
 	builder.WriteString("Files:\n")
 	for _, f := range files {
 		builder.WriteString(fmt.Sprintf("- Name: %s\n", f.Name))
@@ -188,7 +188,6 @@ func (p *MCPProcessor) formatReadFileResult(content string, filename string, tot
 			actualDisplayStartLine = reqStartLine
 		}
 
-
 		// Determine the 1-based actual end line for display
 		actualDisplayEndLine := 0
 		if actualEndLine != -1 {
@@ -206,9 +205,10 @@ func (p *MCPProcessor) formatReadFileResult(content string, filename string, tot
 		} else if reqStartLine == 0 && reqEndLine != 0 && totalLines > 0 { // Beginning of file to end_line
 			actualDisplayStartLine = 1
 			actualDisplayEndLine = reqEndLine
-			if actualDisplayEndLine > totalLines { actualDisplayEndLine = totalLines }
+			if actualDisplayEndLine > totalLines {
+				actualDisplayEndLine = totalLines
+			}
 		}
-
 
 		builder.WriteString(fmt.Sprintf("Requested Range: start_line=%d, end_line=%d\n", reqStartLine, reqEndLine))
 		builder.WriteString(fmt.Sprintf("Actual Range Returned: start_line=%d, end_line=%d\n", actualDisplayStartLine, actualDisplayEndLine))

--- a/internal/models/list.go
+++ b/internal/models/list.go
@@ -20,5 +20,4 @@ type ListFilesRequest struct {
 type ListFilesResponse struct {
 	Files      []FileInfo `json:"files"`
 	TotalCount int        `json:"total_count"`
-	Directory  string     `json:"directory"`
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -28,7 +28,7 @@ const (
 type FileOperationService interface {
 	ReadFile(req models.ReadFileRequest) (content string, filename string, totalLines int, reqStartLine int, reqEndLine int, actualEndLine int, isRangeRequest bool, err *models.ErrorDetail)
 	EditFile(req models.EditFileRequest) (filename string, linesModified int, newTotalLines int, fileCreated bool, err *models.ErrorDetail)
-	ListFiles(req models.ListFilesRequest) ([]models.FileInfo, string, *models.ErrorDetail)
+	ListFiles(req models.ListFilesRequest) ([]models.FileInfo, *models.ErrorDetail)
 }
 
 // DefaultFileOperationService implements the FileOperationService interface.
@@ -588,7 +588,7 @@ func abs(x int) int {
 }
 
 // ListFiles implements the FileOperationService interface.
-func (s *DefaultFileOperationService) ListFiles(req models.ListFilesRequest) ([]models.FileInfo, string, *models.ErrorDetail) {
+func (s *DefaultFileOperationService) ListFiles(req models.ListFilesRequest) ([]models.FileInfo, *models.ErrorDetail) {
 	// Request object is currently empty, so no params to validate from req itself.
 
 	dirEntries, err := s.fsAdapter.ListDir(s.workingDir)
@@ -599,9 +599,9 @@ func (s *DefaultFileOperationService) ListFiles(req models.ListFilesRequest) ([]
 			underlyingErr = unwrapped
 		}
 		if os.IsPermission(underlyingErr) {
-			return nil, "", errors.NewPermissionDeniedError(s.workingDir, "list_dir_working_dir")
+			return nil, errors.NewPermissionDeniedError(s.workingDir, "list_dir_working_dir")
 		}
-		return nil, "", errors.NewFileSystemError(s.workingDir, "list_dir", fmt.Sprintf("Failed to list directory: %v", err))
+		return nil, errors.NewFileSystemError(s.workingDir, "list_dir", fmt.Sprintf("Failed to list directory: %v", err))
 	}
 
 	var files []models.FileInfo
@@ -661,5 +661,5 @@ func (s *DefaultFileOperationService) ListFiles(req models.ListFilesRequest) ([]
 		return files[i].Name < files[j].Name
 	})
 
-	return files, s.workingDir, nil
+	return files, nil
 }

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -843,7 +843,7 @@ func TestListFiles_EmptyDirectory(t *testing.T) {
 	mockFs.listDirEntries[tempWorkingDir] = []filesystem.DirEntryInfo{}
 
 	req := models.ListFilesRequest{}
-	files, dir, err := service.ListFiles(req)
+	files, err := service.ListFiles(req)
 
 	if err != nil {
 		t.Fatalf("ListFiles failed: %v", err.Message)
@@ -851,9 +851,6 @@ func TestListFiles_EmptyDirectory(t *testing.T) {
 
 	if len(files) != 0 {
 		t.Errorf("Expected Files to be empty, got %d items", len(files))
-	}
-	if dir != tempWorkingDir {
-		t.Errorf("Expected directory %s, got %s", tempWorkingDir, dir)
 	}
 }
 
@@ -885,7 +882,7 @@ func TestListFiles_WithFilesHiddenAndDirs(t *testing.T) {
 	// No need to mock stats for .hiddenfile or subdir as they should be filtered out before stats are read by the tested logic
 
 	req := models.ListFilesRequest{}
-	files, dir, err := service.ListFiles(req)
+	files, err := service.ListFiles(req)
 
 	if err != nil {
 		t.Fatalf("ListFiles failed: %v", err.Message)
@@ -893,9 +890,6 @@ func TestListFiles_WithFilesHiddenAndDirs(t *testing.T) {
 
 	if len(files) != 2 {
 		t.Fatalf("Expected 2 files in response, got %d", len(files))
-	}
-	if dir != tempWorkingDir {
-		t.Errorf("Expected directory %s, got %s", tempWorkingDir, dir)
 	}
 
 	// Check sorting and content
@@ -966,7 +960,7 @@ func TestListFiles_LineCounts(t *testing.T) {
 	mockFs.isInvalidUTF8Content[string(invalidUTF8ContentBytes)] = true
 
 	req := models.ListFilesRequest{}
-	files, dir, err := service.ListFiles(req)
+	files, err := service.ListFiles(req)
 
 	if err != nil {
 		t.Fatalf("ListFiles failed: %v", err.Message)
@@ -974,9 +968,6 @@ func TestListFiles_LineCounts(t *testing.T) {
 
 	if len(files) != 5 {
 		t.Fatalf("Expected 5 files in response, got %d", len(files))
-	}
-	if dir != tempWorkingDir {
-		t.Errorf("Expected directory %s, got %s", tempWorkingDir, dir)
 	}
 
 	// Create a map for easy lookup and verification

--- a/internal/transport/http.go
+++ b/internal/transport/http.go
@@ -151,12 +151,12 @@ func (h *HTTPHandler) handleReadFile(w http.ResponseWriter, r *http.Request) {
 // --- Formatting Helpers for HTTP Handler ---
 
 // formatHTTPListFilesResult formats the result for list_files for HTTP responses.
-func formatHTTPListFilesResult(files []models.FileInfo, directory string) string {
+func formatHTTPListFilesResult(files []models.FileInfo) string {
 	if len(files) == 0 {
-		return fmt.Sprintf("No files found in directory: %s", directory)
+		return "No files found"
 	}
 	var builder strings.Builder
-	builder.WriteString(fmt.Sprintf("Directory: %s\nTotal files: %d\n\n", directory, len(files)))
+	builder.WriteString(fmt.Sprintf("Total files: %d\n\n", len(files)))
 	builder.WriteString("Files:\n")
 	for _, f := range files {
 		builder.WriteString(fmt.Sprintf("- Name: %s\n", f.Name))
@@ -384,7 +384,7 @@ func (h *HTTPHandler) handleListFiles(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	files, directory, serviceErr := h.service.ListFiles(req)
+	files, serviceErr := h.service.ListFiles(req)
 	if serviceErr != nil {
 		// Format the error message using the new helper
 		errorText := formatHTTPToolError(serviceErr)
@@ -405,7 +405,7 @@ func (h *HTTPHandler) handleListFiles(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Format the success response using the new helper
-	successText := formatHTTPListFilesResult(files, directory)
+	successText := formatHTTPListFilesResult(files)
 	resp := models.MCPToolResult{
 		Content: []models.MCPToolContent{{Type: "text", Text: successText}},
 		IsError: false,


### PR DESCRIPTION
## Summary
- drop `Directory` field from `ListFilesResponse`
- adjust service and handlers to omit working directory in API
- update tests for new signatures and outputs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6842fda27a3083328956f7f2c566c91f