### PR TITLE
Fix linter issues and format Go code

### DIFF
--- a/cmd/file-editor/main.go
+++ b/cmd/file-editor/main.go
@@ -57,9 +57,10 @@ func main() {
 	switch cfg.Transport {
 	case "http":
 		log.Printf("Initializing HTTP transport on port %d...\n", cfg.Port)
-		// Note: MaxFileSizeMB is a placeholder for the second arg of NewHTTPHandler,
-		// as it currently uses a hardcoded 50MB for HTTP request size.
-		httpHandler := transport.NewHTTPHandler(fileService, cfg.MaxFileSizeMB)
+		// Initialize MCP processor for HTTP mode
+		mcpProcessor := mcp.NewMCPProcessor(fileService)
+		// Note: MaxFileSizeMB is a placeholder for the request size limit.
+		httpHandler := transport.NewHTTPHandler(fileService, mcpProcessor, cfg.MaxFileSizeMB)
 		httpServer = httpHandler.Server // Get the server instance from the handler
 
 		// httpHandler.StartServer will be modified to return the *http.Server instance
@@ -106,7 +107,7 @@ func main() {
 	case "stdio":
 		log.Println("Initializing STDIN/STDOUT JSON-RPC transport...")
 		go func() {
-			mcpProcessor := mcp.NewMCPProcessor(fileService) // Create MCPProcessor
+			mcpProcessor := mcp.NewMCPProcessor(fileService)        // Create MCPProcessor
 			stdioHandler := transport.NewStdioHandler(mcpProcessor) // Pass processor to StdioHandler
 			if err := stdioHandler.Start(os.Stdin, os.Stdout); err != nil {
 				log.Printf("STDIO handler error: %v\n", err)
@@ -159,7 +160,7 @@ func main() {
 		if err != nil {
 			log.Printf("Server/handler stopped due to error: %v\n", err)
 			// close(lockCleanupStopChan) // Removed: No longer needed
-			os.Exit(1)                 // Exit with error if server failed
+			os.Exit(1) // Exit with error if server failed
 		}
 		log.Println("Server/handler stopped normally.")
 		// close(lockCleanupStopChan) // Removed: No longer needed

--- a/internal/mcp/processor.go
+++ b/internal/mcp/processor.go
@@ -2,16 +2,17 @@ package mcp
 
 import (
 	"encoding/json"
+	"file-editor-server/internal/errors"
 	"file-editor-server/internal/models"
 	"file-editor-server/internal/service"
-	"fmt"     // Added import
-	"strings" // Added import
+	"fmt"
+	"strings"
 )
 
 const (
-	protocolVersion = "2024-11-05"
-	serverVersion   = "1.0.0"
-	serverName      = "file-editing-server"
+	protocolVersion   = "2024-11-05"
+	serverVersion     = "1.0.0"
+	serverName        = "file-editing-server"
 	serverDescription = "High-performance file editing server for AI agents"
 )
 
@@ -60,7 +61,7 @@ func (p *MCPProcessor) ProcessRequest(req models.JSONRPCRequest) (*models.MCPToo
 			// Return a standard MCP error if it does.
 			return &models.MCPToolResult{
 				Content: []models.MCPToolContent{
-					{Type: "text", Text: fmt.Sprintf("Error: Failed to marshal initialize response: %v (Code: %d)", err, models.ErrorCodeInternalError)},
+					{Type: "text", Text: fmt.Sprintf("Error: Failed to marshal initialize response: %v (Code: %d)", err, errors.CodeInternalError)},
 				},
 				IsError: true,
 			}, nil
@@ -140,7 +141,7 @@ func (p *MCPProcessor) ProcessRequest(req models.JSONRPCRequest) (*models.MCPToo
 		if err != nil {
 			return &models.MCPToolResult{
 				Content: []models.MCPToolContent{
-					{Type: "text", Text: fmt.Sprintf("Error: Failed to marshal tools/list response: %v (Code: %d)", err, models.ErrorCodeInternalError)},
+					{Type: "text", Text: fmt.Sprintf("Error: Failed to marshal tools/list response: %v (Code: %d)", err, errors.CodeInternalError)},
 				},
 				IsError: true,
 			}, nil
@@ -269,7 +270,7 @@ func (p *MCPProcessor) formatReadFileResult(content string, filename string, tot
 		if content == "" && reqStartLine > 0 { // Range requested yielded no content (e.g. start_line > totalLines)
 			startLineForDisplay = reqStartLine
 			// To show an empty range like "lines 5-4", end_line_for_display should be start_line_for_display - 1
-			endLineForDisplay = reqStartLine -1
+			endLineForDisplay = reqStartLine - 1
 			if endLineForDisplay < 0 { // Avoid negative line numbers if reqStartLine was 1 and content empty
 				endLineForDisplay = 0
 			}
@@ -277,11 +278,11 @@ func (p *MCPProcessor) formatReadFileResult(content string, filename string, tot
 			startLineForDisplay = 1
 			endLineForDisplay = 0
 		} else if content == "" && reqStartLine == 0 && reqEndLine == 0 { // Full read of empty file, but isRangeRequest might be true if service defaults it.
-            // This case should ideally be caught by totalLines == 0 && !isRangeRequest above.
-            // If isRangeRequest is true for a full empty file read, treat as lines 1-0 of 0 total.
-            startLineForDisplay = 1
-            endLineForDisplay = 0
-        } else {
+			// This case should ideally be caught by totalLines == 0 && !isRangeRequest above.
+			// If isRangeRequest is true for a full empty file read, treat as lines 1-0 of 0 total.
+			startLineForDisplay = 1
+			endLineForDisplay = 0
+		} else {
 			if reqStartLine > 0 {
 				startLineForDisplay = reqStartLine
 			} else {
@@ -302,7 +303,6 @@ func (p *MCPProcessor) formatReadFileResult(content string, filename string, tot
 	}
 	return fmt.Sprintf("%s\n\n%s", header, content)
 }
-
 
 // formatEditFileResult formats the result of an edit_file call. (Spec 3.4.3)
 func (p *MCPProcessor) formatEditFileResult(filename string, linesModified int, newTotalLines int, fileCreated bool) string {

--- a/internal/mcp/processor_test.go
+++ b/internal/mcp/processor_test.go
@@ -3,12 +3,10 @@ package mcp
 import (
 	"encoding/json"
 	"file-editor-server/internal/models"
-	"file-editor-server/internal/service" // Will be needed for mock
 	"fmt"
 	"strings"
 	"testing"
 	"time"
-
 	// Mocking framework, if available/preferred, could be used here.
 	// For now, using a simple mock implementation.
 )
@@ -229,7 +227,6 @@ func TestFormatReadFileResult(t *testing.T) {
 		t.Errorf("formatReadFileResult range start 0: expected\n'%s'\ngot\n'%s'", expectedRangeStart0, result)
 	}
 
-
 	// Test line range scenario - content empty (range outside actual lines, e.g., lines 10-12 of a 5 line file)
 	// service.ReadFile returns: content="", filename, totalLines=5, reqStartLine=10, reqEndLine=12, actualEndLine=-1 (or similar to indicate no lines returned), isRangeRequest=true
 	expectedEmptyRange := "File: empty_range.txt (lines 10-9 of 5 total)\n\n"
@@ -292,7 +289,7 @@ func TestMCPProcessor_HandleToolCall_Errors(t *testing.T) {
 			return "", "", 0, 0, 0, 0, false, &models.ErrorDetail{Code: 124, Message: "service read error"}
 		},
 		EditFileFunc: func(req models.EditFileRequest) (string, int, int, bool, *models.ErrorDetail) {
-			return "",0,0,false, &models.ErrorDetail{Code:125, Message:"service edit error"}
+			return "", 0, 0, false, &models.ErrorDetail{Code: 125, Message: "service edit error"}
 		},
 	}
 	processor := NewMCPProcessor(mockService)
@@ -333,8 +330,8 @@ func TestMCPProcessor_HandleToolCall_Errors(t *testing.T) {
 			expectRPCErr:  false,
 		},
 		{
-			name:          "list_files with bad params",
-			toolName:      "list_files",
+			name:     "list_files with bad params",
+			toolName: "list_files",
 			// This causes unmarshal error because ListFilesRequest is an empty struct
 			// so any fields here are "unknown" if DisallowUnknownFields were used,
 			// or simply a type mismatch if it expects {}.
@@ -378,37 +375,37 @@ func TestMCPProcessor_HandleToolCall_Errors(t *testing.T) {
 // TestExecuteTool is similar to handleToolCall but takes parsed args.
 // This mainly tests the type assertions and error paths for ExecuteTool itself.
 func TestMCPProcessor_ExecuteTool_ErrorsAndBasic(t *testing.T) {
-    mockService := &MockFileOperationService{
-        ListFilesFunc: func(req models.ListFilesRequest) ([]models.FileInfo, *models.ErrorDetail) {
-            if req == (models.ListFilesRequest{}) { // Basic check for valid empty request
-                 return []models.FileInfo{{Name: "test.txt", Lines: 1, Modified: "2023-01-01T00:00:00Z"}}, nil
-            }
-            return nil, &models.ErrorDetail{Code: 700, Message: "list files error in ExecuteTool"}
-        },
-    }
-    processor := NewMCPProcessor(mockService)
+	mockService := &MockFileOperationService{
+		ListFilesFunc: func(req models.ListFilesRequest) ([]models.FileInfo, *models.ErrorDetail) {
+			if req == (models.ListFilesRequest{}) { // Basic check for valid empty request
+				return []models.FileInfo{{Name: "test.txt", Lines: 1, Modified: "2023-01-01T00:00:00Z"}}, nil
+			}
+			return nil, &models.ErrorDetail{Code: 700, Message: "list files error in ExecuteTool"}
+		},
+	}
+	processor := NewMCPProcessor(mockService)
 
-    // Valid call
-    _, err := processor.ExecuteTool("list_files", models.ListFilesRequest{})
-    if err != nil {
-        t.Errorf("ExecuteTool with valid args for list_files failed: %v", err)
-    }
+	// Valid call
+	_, err := processor.ExecuteTool("list_files", models.ListFilesRequest{})
+	if err != nil {
+		t.Errorf("ExecuteTool with valid args for list_files failed: %v", err)
+	}
 
-    // Invalid argument type
-    expectedErrText := "invalid arguments type for list_files: expected models.ListFilesRequest, got string"
-    _, err = processor.ExecuteTool("list_files", "not-a-struct")
-    if err == nil || err.Error() != expectedErrText {
-        t.Errorf("ExecuteTool with invalid arg type: expected error '%s', got '%v'", expectedErrText, err)
-    }
+	// Invalid argument type
+	expectedErrText := "invalid arguments type for list_files: expected models.ListFilesRequest, got string"
+	_, err = processor.ExecuteTool("list_files", "not-a-struct")
+	if err == nil || err.Error() != expectedErrText {
+		t.Errorf("ExecuteTool with invalid arg type: expected error '%s', got '%v'", expectedErrText, err)
+	}
 
-    // Unknown tool
-    res, err := processor.ExecuteTool("super_tool", models.ListFilesRequest{})
-    if err != nil { // ExecuteTool returns MCPToolResult for unknown tool, not an error directly
-        t.Errorf("ExecuteTool with unknown tool returned an unexpected error: %v", err)
-    }
-    if !res.IsError || !strings.Contains(res.Content[0].Text, "Error: Unknown tool 'super_tool'.") {
-         t.Errorf("ExecuteTool with unknown tool: unexpected result: %+v", res)
-    }
+	// Unknown tool
+	res, err := processor.ExecuteTool("super_tool", models.ListFilesRequest{})
+	if err != nil { // ExecuteTool returns MCPToolResult for unknown tool, not an error directly
+		t.Errorf("ExecuteTool with unknown tool returned an unexpected error: %v", err)
+	}
+	if !res.IsError || !strings.Contains(res.Content[0].Text, "Error: Unknown tool 'super_tool'.") {
+		t.Errorf("ExecuteTool with unknown tool: unexpected result: %+v", res)
+	}
 }
 
 func init() {
@@ -419,35 +416,35 @@ func init() {
 // Example of how you might test ProcessRequest for "tools/call"
 // This would involve more setup for the mock service.
 func TestMCPProcessor_ProcessRequest_ToolsCall_ListFiles(t *testing.T) {
-    mockService := &MockFileOperationService{
-        ListFilesFunc: func(req models.ListFilesRequest) ([]models.FileInfo, *models.ErrorDetail) {
-            return []models.FileInfo{
-                {Name: "alpha.txt", Lines: 10, Modified: time.Now().UTC().Format(time.RFC3339)},
-            }, nil
-        },
-    }
-    processor := NewMCPProcessor(mockService)
+	mockService := &MockFileOperationService{
+		ListFilesFunc: func(req models.ListFilesRequest) ([]models.FileInfo, *models.ErrorDetail) {
+			return []models.FileInfo{
+				{Name: "alpha.txt", Lines: 10, Modified: time.Now().UTC().Format(time.RFC3339)},
+			}, nil
+		},
+	}
+	processor := NewMCPProcessor(mockService)
 
-    argsJSON := `{}`
-    paramsJSON := fmt.Sprintf(`{"name":"list_files", "arguments": %s}`, argsJSON)
+	argsJSON := `{}`
+	paramsJSON := fmt.Sprintf(`{"name":"list_files", "arguments": %s}`, argsJSON)
 
-    rpcReq := models.JSONRPCRequest{
-        JSONRPC: "2.0",
-        Method:  "tools/call",
-        Params:  json.RawMessage(paramsJSON),
-        ID:      "test-id-list",
-    }
+	rpcReq := models.JSONRPCRequest{
+		JSONRPC: "2.0",
+		Method:  "tools/call",
+		Params:  json.RawMessage(paramsJSON),
+		ID:      "test-id-list",
+	}
 
-    result, rpcErr := processor.ProcessRequest(rpcReq)
-    if rpcErr != nil {
-        t.Fatalf("ProcessRequest(tools/call list_files) returned RPC error: %v", rpcErr)
-    }
-    if result.IsError {
-        t.Fatalf("ProcessRequest(tools/call list_files) result IsError=true: %s", result.Content[0].Text)
-    }
-    // Further checks on result.Content[0].Text would verify the formatted output
-    // which is already covered by TestFormatListFilesResult
-    if !strings.Contains(result.Content[0].Text, "name: alpha.txt") {
-        t.Errorf("Expected list_files output to contain 'name: alpha.txt', got: %s", result.Content[0].Text)
-    }
+	result, rpcErr := processor.ProcessRequest(rpcReq)
+	if rpcErr != nil {
+		t.Fatalf("ProcessRequest(tools/call list_files) returned RPC error: %v", rpcErr)
+	}
+	if result.IsError {
+		t.Fatalf("ProcessRequest(tools/call list_files) result IsError=true: %s", result.Content[0].Text)
+	}
+	// Further checks on result.Content[0].Text would verify the formatted output
+	// which is already covered by TestFormatListFilesResult
+	if !strings.Contains(result.Content[0].Text, "name: alpha.txt") {
+		t.Errorf("Expected list_files output to contain 'name: alpha.txt', got: %s", result.Content[0].Text)
+	}
 }

--- a/internal/transport/http_test.go
+++ b/internal/transport/http_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"file-editor-server/internal/errors" // Using for error codes if needed
-	"file-editor-server/internal/mcp"
 	"file-editor-server/internal/models"
 	"fmt"
 	"io"
@@ -162,7 +161,7 @@ func TestHTTPHandler_InvalidToolArguments(t *testing.T) {
 		body, _ := io.ReadAll(respMalformed.Body)
 		t.Errorf("Expected status %d for malformed JSON, got %d. Body: %s", http.StatusBadRequest, respMalformed.StatusCode, string(body))
 	}
-	respMalformed.Body.Close()
+	_ = respMalformed.Body.Close()
 
 	// JSON not matching schema (e.g. unknown field, if DisallowUnknownFields is active)
 	// models.ReadFileRequest has Name, StartLine, EndLine.
@@ -179,7 +178,7 @@ func TestHTTPHandler_InvalidToolArguments(t *testing.T) {
 	if errResp.Error.Code != errors.CodeParseError || !strings.Contains(errResp.Error.Message, "unknown field") {
 		t.Errorf("Unexpected error response for unknown field: %+v", errResp.Error)
 	}
-	respUnknown.Body.Close()
+	_ = respUnknown.Body.Close()
 }
 
 func TestHTTPHandler_MCPProcessorError(t *testing.T) {
@@ -207,11 +206,11 @@ func TestHTTPHandler_MCPProcessorError(t *testing.T) {
 	if errResp.Error.Code != errors.CodeInternalError || !strings.Contains(errResp.Error.Message, "internal processor issue") {
 		t.Errorf("Unexpected error response for MCPProcessor error: %+v", errResp.Error)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 }
 
 func TestHTTPHandler_TransportErrors(t *testing.T) {
-	mockProcessor := &MockMCPProcessor{} // Not called for these
+	mockProcessor := &MockMCPProcessor{}             // Not called for these
 	handler := NewHTTPHandler(nil, mockProcessor, 1) // 1MB max size
 
 	// Test MethodNotAllowed
@@ -260,7 +259,7 @@ func TestHTTPHandler_HealthCheck(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GET request to /health failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("expected status %d for /health, got %d", http.StatusOK, resp.StatusCode)

--- a/internal/transport/stdio.go
+++ b/internal/transport/stdio.go
@@ -70,7 +70,9 @@ func (h *StdioHandler) Start(input io.Reader, output io.Writer) error {
 			var idForErrorResponse interface{}
 			// Attempt to extract ID specifically for this error response.
 			// This is a best-effort attempt, so we can ignore the error from this particular Unmarshal.
-			var idExtractor struct { ID interface{} `json:"id"` }
+			var idExtractor struct {
+				ID interface{} `json:"id"`
+			}
 			_ = json.Unmarshal(lineBytes, &idExtractor)
 			idForErrorResponse = idExtractor.ID
 

--- a/internal/transport/stdio_test.go
+++ b/internal/transport/stdio_test.go
@@ -11,27 +11,6 @@ import (
 	"testing"
 )
 
-// MockMCPProcessor is a mock implementation of mcp.MCPProcessorInterface.
-// Copied from http_test.go - ideally this would be in a shared test/mocks package.
-type MockMCPProcessor struct {
-	ExecuteToolFunc    func(toolName string, argumentsStruct interface{}) (*models.MCPToolResult, error)
-	ProcessRequestFunc func(req models.JSONRPCRequest) (*models.MCPToolResult, *models.JSONRPCError)
-}
-
-func (m *MockMCPProcessor) ExecuteTool(toolName string, argumentsStruct interface{}) (*models.MCPToolResult, error) {
-	if m.ExecuteToolFunc != nil {
-		return m.ExecuteToolFunc(toolName, argumentsStruct)
-	}
-	return nil, fmt.Errorf("ExecuteToolFunc not implemented")
-}
-
-func (m *MockMCPProcessor) ProcessRequest(req models.JSONRPCRequest) (*models.MCPToolResult, *models.JSONRPCError) {
-	if m.ProcessRequestFunc != nil {
-		return m.ProcessRequestFunc(req)
-	}
-	return nil, &models.JSONRPCError{Code: -32000, Message: "ProcessRequestFunc not implemented in stdio test mock"}
-}
-
 // runStdioTestHelper simulates running the StdioHandler with given input and returns the output string.
 func runStdioTestHelper(t *testing.T, handler *StdioHandler, input string) string {
 	var outputBuffer bytes.Buffer
@@ -206,7 +185,7 @@ func TestStdioHandler_InvalidJSONRPC(t *testing.T) {
 		input := `{"method": "test", "id": 2}` + "\n"
 		output := runStdioTestHelper(t, handler, input)
 		var resp models.JSONRPCResponse
-		json.Unmarshal([]byte(output), &resp) // Ignore error, check fields
+		_ = json.Unmarshal([]byte(output), &resp)           // Ignore error, check fields
 		if resp.Error == nil || resp.Error.Code != -32600 { // Invalid Request
 			t.Errorf("Expected error code -32600 for missing version, got %+v", resp.Error)
 		}
@@ -219,7 +198,7 @@ func TestStdioHandler_InvalidJSONRPC(t *testing.T) {
 		input := `{"jsonrpc": "2.0", "id": 3}` + "\n"
 		output := runStdioTestHelper(t, handler, input)
 		var resp models.JSONRPCResponse
-		json.Unmarshal([]byte(output), &resp) // Ignore error, check fields
+		_ = json.Unmarshal([]byte(output), &resp)           // Ignore error, check fields
 		if resp.Error == nil || resp.Error.Code != -32600 { // Invalid Request
 			t.Errorf("Expected error code -32600 for missing method, got %+v", resp.Error)
 		}


### PR DESCRIPTION
## Summary
- update HTTP handler to accept MCP processor and remove unused helpers
- clean up MCP processor error constants and imports
- simplify lock manager tests for new API
- deduplicate mocks and fix errcheck warnings
- run gofmt across the repository

## Testing
- `golangci-lint run ./...`
- `go test ./...` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_68433d87d004833293ae40e88db80be5