### PR TITLE
Implement CLI argument parsing

### DIFF
--- a/ghostwriter/Cargo.lock
+++ b/ghostwriter/Cargo.lock
@@ -437,6 +437,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +543,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-tungstenite",
 ]
@@ -820,6 +827,12 @@ checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1224,6 +1237,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/ghostwriter/Cargo.toml
+++ b/ghostwriter/Cargo.toml
@@ -16,3 +16,6 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 tokio = { version = "1.45.1", features = ["rt", "rt-multi-thread", "macros"] }
 tokio-tungstenite = "0.27.0"
+
+[dev-dependencies]
+tempfile = "3.10.1"

--- a/ghostwriter/src/cli/mod.rs
+++ b/ghostwriter/src/cli/mod.rs
@@ -1,0 +1,119 @@
+use clap::{ArgGroup, Parser};
+use std::path::PathBuf;
+
+/// Command line arguments for Ghostwriter
+#[derive(Debug, Parser, PartialEq)]
+#[command(author, version, about)]
+#[command(group(
+    ArgGroup::new("mode")
+        .required(true)
+        .args(["path", "server", "connect"]),
+))]
+pub struct Args {
+    /// Open a local file or directory
+    pub path: Option<PathBuf>,
+
+    /// Start in server mode with the given workspace directory
+    #[arg(long)]
+    pub server: Option<PathBuf>,
+
+    /// Connect to a remote server WebSocket URL
+    #[arg(long)]
+    pub connect: Option<String>,
+
+    /// Bind address for server mode
+    #[arg(long, default_value = "127.0.0.1")]
+    pub bind: String,
+
+    /// Port for server mode
+    #[arg(long, default_value_t = 8080)]
+    pub port: u16,
+
+    /// Optional authentication key
+    #[arg(long)]
+    pub key: Option<String>,
+}
+
+impl Args {
+    /// Validate file or directory paths exist when provided
+    pub fn validate(&self) -> Result<(), String> {
+        if let Some(path) = &self.path {
+            if !path.exists() {
+                return Err(format!("path does not exist: {}", path.display()));
+            }
+        }
+        if let Some(dir) = &self.server {
+            if !dir.is_dir() {
+                return Err(format!(
+                    "server path must be a directory: {}",
+                    dir.display()
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Args;
+    use clap::Parser;
+    use tempfile::{NamedTempFile, TempDir};
+
+    #[test]
+    fn test_parse_local_file_args() {
+        let file = NamedTempFile::new().unwrap();
+        let path = file.path().to_str().unwrap();
+        let args = Args::try_parse_from(["ghostwriter", path]).unwrap();
+        assert_eq!(args.path.as_deref().unwrap(), file.path());
+        assert!(args.validate().is_ok());
+    }
+
+    #[test]
+    fn test_parse_server_args() {
+        let dir = TempDir::new().unwrap();
+        let dpath = dir.path().to_str().unwrap();
+        let args = Args::try_parse_from([
+            "ghostwriter",
+            "--server",
+            dpath,
+            "--port",
+            "8080",
+            "--key",
+            "secret",
+        ])
+        .unwrap();
+        assert_eq!(args.server.as_deref().unwrap(), dir.path());
+        assert_eq!(args.port, 8080);
+        assert_eq!(args.key.as_deref(), Some("secret"));
+        assert!(args.validate().is_ok());
+    }
+
+    #[test]
+    fn test_parse_client_args() {
+        let args = Args::try_parse_from([
+            "ghostwriter",
+            "--connect",
+            "ws://server:8080",
+            "--key",
+            "secret",
+        ])
+        .unwrap();
+        assert_eq!(args.connect.as_deref(), Some("ws://server:8080"));
+        assert_eq!(args.key.as_deref(), Some("secret"));
+        assert!(args.validate().is_ok());
+    }
+
+    #[test]
+    fn test_invalid_args_rejected() {
+        let dir = TempDir::new().unwrap();
+        let result = Args::try_parse_from([
+            "ghostwriter",
+            "--server",
+            dir.path().to_str().unwrap(),
+            "--connect",
+            "ws://server:8080",
+        ]);
+        assert!(result.is_err());
+    }
+}

--- a/ghostwriter/src/main.rs
+++ b/ghostwriter/src/main.rs
@@ -1,11 +1,20 @@
 mod app;
+mod cli;
 mod editor;
 mod files;
 mod network;
 mod ui;
 
+use clap::Parser;
+
 fn main() {
-    println!("Hello, world!");
+    let args = cli::Args::parse();
+    if let Err(e) = args.validate() {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    }
+    println!("Parsed arguments: {args:?}");
+    // Placeholder module calls
     app::hello_app();
     editor::hello_editor();
     files::hello_files();


### PR DESCRIPTION
## Summary
- add CLI module with argument parsing via clap
- validate paths for file and server modes
- test CLI arguments for file, server, client, and invalid combinations
- parse CLI in main with basic error handling

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685ae8c98c088332b81769d6ee73b518