### PR TITLE
Implement basic error handling system

### DIFF
--- a/ghostwriter/src/cli/mod.rs
+++ b/ghostwriter/src/cli/mod.rs
@@ -36,17 +36,16 @@ pub struct Args {
 
 impl Args {
     /// Validate file or directory paths exist when provided
-    pub fn validate(&self) -> Result<(), String> {
+    pub fn validate(&self) -> crate::error::Result<()> {
         if let Some(path) = &self.path {
             if !path.exists() {
-                return Err(format!("path does not exist: {}", path.display()));
+                return Err(crate::error::GhostwriterError::FileNotFound);
             }
         }
         if let Some(dir) = &self.server {
             if !dir.is_dir() {
-                return Err(format!(
-                    "server path must be a directory: {}",
-                    dir.display()
+                return Err(crate::error::GhostwriterError::InvalidArgument(
+                    "server path must be a directory".into(),
                 ));
             }
         }

--- a/ghostwriter/src/error.rs
+++ b/ghostwriter/src/error.rs
@@ -1,0 +1,123 @@
+use std::fmt;
+use std::io;
+
+/// Result alias using `GhostwriterError`.
+pub type Result<T> = std::result::Result<T, GhostwriterError>;
+
+/// Primary error type for Ghostwriter.
+#[derive(Debug)]
+pub enum GhostwriterError {
+    /// File was not found on disk.
+    FileNotFound,
+    /// Operation failed due to insufficient permissions.
+    PermissionDenied,
+    /// Any network related error.
+    Network(String),
+    /// Catch-all for other I/O errors.
+    Io(io::Error),
+    /// Invalid argument or input.
+    InvalidArgument(String),
+}
+
+impl fmt::Display for GhostwriterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GhostwriterError::FileNotFound => write!(f, "file not found"),
+            GhostwriterError::PermissionDenied => write!(f, "permission denied"),
+            GhostwriterError::Network(msg) => write!(f, "network error: {msg}"),
+            GhostwriterError::Io(err) => write!(f, "io error: {err}"),
+            GhostwriterError::InvalidArgument(msg) => write!(f, "invalid argument: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for GhostwriterError {}
+
+impl From<io::Error> for GhostwriterError {
+    fn from(err: io::Error) -> Self {
+        use io::ErrorKind::*;
+        match err.kind() {
+            NotFound => GhostwriterError::FileNotFound,
+            PermissionDenied => GhostwriterError::PermissionDenied,
+            _ => GhostwriterError::Io(err),
+        }
+    }
+}
+
+impl From<tokio_tungstenite::tungstenite::Error> for GhostwriterError {
+    fn from(err: tokio_tungstenite::tungstenite::Error) -> Self {
+        GhostwriterError::Network(err.to_string())
+    }
+}
+
+/// Error type carrying additional context string.
+#[derive(Debug)]
+pub struct ContextualError {
+    context: String,
+    source: GhostwriterError,
+}
+
+#[allow(dead_code)]
+impl ContextualError {
+    /// Create a new contextual error.
+    pub fn new(context: impl Into<String>, source: GhostwriterError) -> Self {
+        Self {
+            context: context.into(),
+            source,
+        }
+    }
+
+    /// Access the underlying error.
+    pub fn source(&self) -> &GhostwriterError {
+        &self.source
+    }
+}
+
+impl fmt::Display for ContextualError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.context, self.source)
+    }
+}
+
+impl std::error::Error for ContextualError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+#[allow(dead_code)]
+impl GhostwriterError {
+    /// Attach a context string to the error.
+    pub fn with_context(self, ctx: impl Into<String>) -> ContextualError {
+        ContextualError::new(ctx, self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+
+    #[test]
+    fn test_file_not_found_error() {
+        let err: GhostwriterError = File::open("/no/such/file").map_err(Into::into).unwrap_err();
+        assert!(matches!(err, GhostwriterError::FileNotFound));
+        assert_eq!(err.to_string(), "file not found");
+    }
+
+    #[test]
+    fn test_permission_denied_error() {
+        let io_err = io::Error::from(io::ErrorKind::PermissionDenied);
+        let err: GhostwriterError = io_err.into();
+        assert!(matches!(err, GhostwriterError::PermissionDenied));
+    }
+
+    #[test]
+    fn test_network_error_conversion() {
+        use tokio_tungstenite::tungstenite::error::{Error as WsError, ProtocolError};
+        let ws_err = WsError::Protocol(ProtocolError::SendAfterClosing);
+        let err: GhostwriterError = ws_err.into();
+        assert!(matches!(err, GhostwriterError::Network(_)));
+        assert!(err.to_string().contains("closing"));
+    }
+}

--- a/ghostwriter/src/main.rs
+++ b/ghostwriter/src/main.rs
@@ -1,15 +1,19 @@
 mod app;
 mod cli;
 mod editor;
+mod error;
 mod files;
 mod network;
 mod ui;
 
 use clap::Parser;
+use log::error;
 
 fn main() {
+    env_logger::init();
     let args = cli::Args::parse();
     if let Err(e) = args.validate() {
+        error!("{e}");
         eprintln!("Error: {e}");
         std::process::exit(1);
     }


### PR DESCRIPTION
## Summary
- add new `error` module with `GhostwriterError`
- integrate logging and error handling in `main`
- return error types from CLI validation
- add unit tests for error handling

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685aeb797228833290a043033160b642