### PR TITLE
Implement cursor management system

### DIFF
--- a/ghostwriter/src/editor/cursor.rs
+++ b/ghostwriter/src/editor/cursor.rs
@@ -1,0 +1,224 @@
+use crate::editor::rope::Rope;
+
+/// Represents a cursor position within a text document.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub struct Cursor {
+    line: usize,
+    column: usize,
+}
+
+#[allow(dead_code)]
+impl Cursor {
+    /// Create a new cursor at the beginning of the document.
+    pub fn new() -> Self {
+        Self { line: 0, column: 0 }
+    }
+
+    /// Get the current cursor position as `(line, column)`.
+    pub fn position(&self) -> (usize, usize) {
+        (self.line, self.column)
+    }
+
+    /// Move the cursor to the start of the document.
+    pub fn move_doc_start(&mut self) {
+        self.line = 0;
+        self.column = 0;
+    }
+
+    /// Move the cursor to the end of the document.
+    pub fn move_doc_end(&mut self, rope: &Rope) {
+        let text = normalized_text(rope);
+        if text.is_empty() {
+            self.move_doc_start();
+            return;
+        }
+        self.line = text.lines().count() - 1;
+        if let Some(last) = text.lines().last() {
+            self.column = last.chars().count();
+        } else {
+            self.column = 0;
+        }
+    }
+
+    /// Move the cursor to the start of the current line.
+    pub fn move_line_start(&mut self) {
+        self.column = 0;
+    }
+
+    /// Move the cursor to the end of the current line.
+    pub fn move_line_end(&mut self, rope: &Rope) {
+        let text = normalized_text(rope);
+        if let Some(line) = text.lines().nth(self.line) {
+            self.column = line.chars().count();
+        }
+    }
+
+    /// Move the cursor to the previous word start.
+    pub fn move_prev_word(&mut self, rope: &Rope) {
+        let text = normalized_text(rope);
+        let idx = line_col_to_index(&text, self.line, self.column);
+        if idx == 0 {
+            return;
+        }
+        let chars: Vec<(usize, char)> = text.char_indices().collect();
+        let mut pos = chars
+            .iter()
+            .position(|(i, _)| *i >= idx)
+            .unwrap_or(chars.len());
+        while pos > 0 && !is_word_char(chars[pos - 1].1) {
+            pos -= 1;
+        }
+        while pos > 0 && is_word_char(chars[pos - 1].1) {
+            pos -= 1;
+        }
+        let new_idx = if pos < chars.len() { chars[pos].0 } else { 0 };
+        let (line, col) = index_to_line_col(&text, new_idx);
+        self.line = line;
+        self.column = col;
+    }
+
+    /// Move the cursor to the next word end.
+    pub fn move_next_word(&mut self, rope: &Rope) {
+        let text = normalized_text(rope);
+        let idx = line_col_to_index(&text, self.line, self.column);
+        let chars: Vec<(usize, char)> = text.char_indices().collect();
+        let len = chars.len();
+        let mut pos = chars.iter().position(|(i, _)| *i > idx).unwrap_or(len);
+        while pos < len && !is_word_char(chars[pos].1) {
+            pos += 1;
+        }
+        if pos >= len {
+            self.move_doc_end(rope);
+            return;
+        }
+        let mut end = pos;
+        while end < len && is_word_char(chars[end].1) {
+            end += 1;
+        }
+        let end_idx = if end == 0 { 0 } else { chars[end - 1].0 };
+        let (line, col) = index_to_line_col(&text, end_idx);
+        self.line = line;
+        self.column = col;
+    }
+
+    /// Ensure the cursor is within valid bounds of the document.
+    pub fn validate(&mut self, rope: &Rope) {
+        let text = normalized_text(rope);
+        let mut lines: Vec<&str> = text.lines().collect();
+        if lines.is_empty() {
+            lines.push("");
+        }
+        if self.line >= lines.len() {
+            self.line = lines.len() - 1;
+        }
+        let max_col = lines[self.line].chars().count();
+        if self.column > max_col {
+            self.column = max_col;
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn normalized_text(rope: &Rope) -> String {
+    rope.as_string().replace("\r\n", "\n").replace('\r', "\n")
+}
+
+#[allow(dead_code)]
+fn line_col_to_index(text: &str, line: usize, column: usize) -> usize {
+    let mut l = 0;
+    let mut c = 0;
+    for (i, ch) in text.char_indices() {
+        if l == line && c == column {
+            return i;
+        }
+        if ch == '\n' {
+            l += 1;
+            c = 0;
+        } else {
+            c += 1;
+        }
+    }
+    if l == line && c == column {
+        return text.len();
+    }
+    text.len()
+}
+
+#[allow(dead_code)]
+fn index_to_line_col(text: &str, idx: usize) -> (usize, usize) {
+    let mut l = 0;
+    let mut c = 0;
+    for (i, ch) in text.char_indices() {
+        if i >= idx {
+            break;
+        }
+        if ch == '\n' {
+            l += 1;
+            c = 0;
+        } else {
+            c += 1;
+        }
+    }
+    (l, c)
+}
+
+#[allow(dead_code)]
+fn is_word_char(ch: char) -> bool {
+    ch.is_alphanumeric() || ch == '_'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rope(text: &str) -> Rope {
+        Rope::from_str(text)
+    }
+
+    #[test]
+    fn test_cursor_word_navigation() {
+        let r = rope("hello world foo_bar");
+        let mut c = Cursor::new();
+        c.move_next_word(&r);
+        assert_eq!(c.position(), (0, 4));
+        c.move_next_word(&r);
+        assert_eq!(c.position(), (0, 10));
+        c.move_prev_word(&r);
+        assert_eq!(c.position(), (0, 6));
+        c.move_prev_word(&r);
+        assert_eq!(c.position(), (0, 0));
+    }
+
+    #[test]
+    fn test_cursor_line_boundaries() {
+        let r = rope("line1\nline2");
+        let mut c = Cursor { line: 1, column: 2 };
+        c.move_line_start();
+        assert_eq!(c.position(), (1, 0));
+        c.column = 1;
+        c.move_line_end(&r);
+        assert_eq!(c.position(), (1, 5));
+    }
+
+    #[test]
+    fn test_cursor_document_boundaries() {
+        let r = rope("a\nb\nc");
+        let mut c = Cursor { line: 1, column: 1 };
+        c.move_doc_start();
+        assert_eq!(c.position(), (0, 0));
+        c.move_doc_end(&r);
+        assert_eq!(c.position(), (2, 1));
+    }
+
+    #[test]
+    fn test_cursor_validation() {
+        let r = rope("foo\r\nbar");
+        let mut c = Cursor {
+            line: 10,
+            column: 10,
+        };
+        c.validate(&r);
+        assert_eq!(c.position(), (1, 3));
+    }
+}

--- a/ghostwriter/src/editor/mod.rs
+++ b/ghostwriter/src/editor/mod.rs
@@ -1,4 +1,5 @@
 // editor module
+pub mod cursor;
 pub mod rope;
 
 pub fn hello_editor() {


### PR DESCRIPTION
## Summary
- add `Cursor` struct with word, line, and document navigation
- support both LF and CRLF via newline normalization
- enforce cursor bounds with `validate`
- expose new module in editor
- add comprehensive unit tests

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685af76812fc83328913b9f822702ee5