### PR TITLE
test: add missing edge case coverage for editor components

### DIFF
--- a/ghostwriter/src/editor/cursor.rs
+++ b/ghostwriter/src/editor/cursor.rs
@@ -274,4 +274,33 @@ mod tests {
         c.validate(&r);
         assert_eq!(c.position(), (1, 3));
     }
+
+    #[test]
+    fn test_cursor_boundary_movements() {
+        let r = rope("line1\nline2");
+        let mut c = Cursor::new();
+        c.move_left(&r);
+        assert_eq!(c.position(), (0, 0));
+        c.move_doc_end(&r);
+        let end = c.position();
+        c.move_right(&r);
+        assert_eq!(c.position(), end);
+        c.move_doc_start();
+        c.move_up(&r);
+        assert_eq!(c.position(), (0, 0));
+        c.move_doc_end(&r);
+        c.move_down(&r);
+        assert_eq!(c.position(), end);
+    }
+
+    #[test]
+    fn test_cursor_word_navigation_edges() {
+        let r = rope("foo bar");
+        let mut c = Cursor::new();
+        c.move_prev_word(&r);
+        assert_eq!(c.position(), (0, 0));
+        c.move_doc_end(&r);
+        c.move_next_word(&r);
+        assert_eq!(c.position(), (0, 7));
+    }
 }

--- a/ghostwriter/src/editor/rope.rs
+++ b/ghostwriter/src/editor/rope.rs
@@ -294,4 +294,34 @@ mod tests {
         let r = Rope::from_bytes(&bytes);
         assert_eq!(r.as_string(), "f<80>g");
     }
+
+    #[test]
+    fn test_rope_insert_empty_and_delete_all() {
+        let mut r = Rope::new();
+        r.insert(0, "abc");
+        assert_eq!(r.as_string(), "abc");
+        r.delete(0..r.len_chars());
+        assert!(r.as_string().is_empty());
+    }
+
+    #[test]
+    fn test_rope_slice_across_chunks() {
+        let mut data = "a".repeat(CHUNK_SIZE + 10);
+        data.push_str(&"b".repeat(20));
+        let r = Rope::from_str(&data);
+        let slice = r.slice(CHUNK_SIZE - 5..CHUNK_SIZE + 15);
+        assert_eq!(slice.chars().count(), 20);
+    }
+
+    #[test]
+    fn test_char_at_out_of_bounds() {
+        let r = Rope::from_str("abc");
+        assert_eq!(r.char_at(5), None);
+    }
+
+    #[test]
+    fn test_line_at_out_of_bounds() {
+        let r = Rope::from_str("a\nb");
+        assert_eq!(r.line_at(5), None);
+    }
 }

--- a/ghostwriter/src/editor/selection.rs
+++ b/ghostwriter/src/editor/selection.rs
@@ -134,4 +134,17 @@ mod tests {
         sel.normalize();
         assert_eq!(sel.copy(&rope), "b\ncd");
     }
+
+    #[test]
+    fn test_selection_empty_ops() {
+        let rope = Rope::from_str("abc");
+        let cursor = Cursor::new();
+        let sel = Selection::new(cursor);
+        assert_eq!(sel.copy(&rope), "");
+
+        let mut r2 = rope.clone();
+        sel.delete(&mut r2);
+        assert_eq!(r2.as_string(), rope.as_string());
+        assert_eq!(sel.cut(&mut r2), "");
+    }
 }

--- a/ghostwriter/src/editor/undo.rs
+++ b/ghostwriter/src/editor/undo.rs
@@ -187,4 +187,30 @@ mod tests {
         assert!(stack.undo(&mut rope, &mut cursor));
         assert_eq!(cursor, before);
     }
+
+    #[test]
+    fn test_undo_redo_empty_stack() {
+        let mut stack = UndoStack::new(1);
+        let mut rope = Rope::new();
+        let mut cursor = Cursor::new();
+        assert!(!stack.undo(&mut rope, &mut cursor));
+        assert!(!stack.redo(&mut rope, &mut cursor));
+    }
+
+    #[test]
+    fn test_clear_stack() {
+        let mut rope = Rope::from_str("a");
+        let mut cursor = Cursor::new();
+        let mut stack = UndoStack::new(10);
+        stack.push(UndoRecord {
+            op: UndoOperation::Insert {
+                index: 0,
+                text: "a".to_string(),
+            },
+            before: cursor,
+            after: cursor,
+        });
+        stack.clear();
+        assert!(!stack.undo(&mut rope, &mut cursor));
+    }
 }


### PR DESCRIPTION
## Summary
- verify Phase 2 features of Rope, Cursor, Selection and Undo modules
- add unit tests for boundary conditions and empty operations

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685b0776433c83328ff68786c9c5e652