### PR TITLE
Implement WebSocket protocol messages

### DIFF
--- a/ghostwriter/Cargo.lock
+++ b/ghostwriter/Cargo.lock
@@ -152,6 +152,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +609,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-tungstenite",
+ "uuid",
 ]
 
 [[package]]
@@ -733,6 +740,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1479,6 +1496,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,6 +1536,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]

--- a/ghostwriter/Cargo.toml
+++ b/ghostwriter/Cargo.toml
@@ -14,6 +14,7 @@ notify = "8.0.0"
 ratatui = "0.29.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+uuid = { version = "1.17.0", features = ["serde", "v4"] }
 tokio = { version = "1.45.1", features = ["rt", "rt-multi-thread", "macros"] }
 tokio-tungstenite = "0.27.0"
 tempfile = "3.10.1"

--- a/ghostwriter/src/network/mod.rs
+++ b/ghostwriter/src/network/mod.rs
@@ -1,4 +1,6 @@
-// network module
+pub mod protocol;
+
+/// Placeholder network entry point.
 pub fn hello_network() {
     println!("Hello from network module!");
 }

--- a/ghostwriter/src/network/protocol.rs
+++ b/ghostwriter/src/network/protocol.rs
@@ -1,0 +1,97 @@
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Represents a protocol message exchanged over WebSockets.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct Message {
+    /// Unique identifier used for matching requests and responses.
+    pub id: Uuid,
+    /// Specific message variant.
+    #[serde(flatten)]
+    pub kind: MessageKind,
+}
+
+impl Message {
+    /// Returns `true` if this message corresponds to the other by ID.
+    #[allow(dead_code)]
+    pub fn matches(&self, other: &Message) -> bool {
+        self.id == other.id
+    }
+}
+
+/// Variants of protocol messages.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum MessageKind {
+    /// Client initiates authentication with optional key.
+    AuthRequest { key: Option<String> },
+    /// Server replies with authentication result.
+    AuthResponse {
+        success: bool,
+        reason: Option<String>,
+    },
+    /// Simple ping to keep connection alive.
+    Ping,
+    /// Response to `Ping` messages.
+    Pong,
+    /// Error message with human readable context.
+    Error { context: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_message_serialization() {
+        let msg = Message {
+            id: Uuid::nil(),
+            kind: MessageKind::Ping,
+        };
+        let json = serde_json::to_string(&msg).expect("serialize");
+        let de: Message = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(msg, de);
+    }
+
+    #[test]
+    fn test_request_id_system() {
+        let id = Uuid::new_v4();
+        let req = Message {
+            id,
+            kind: MessageKind::AuthRequest {
+                key: Some("k".into()),
+            },
+        };
+        let res = Message {
+            id,
+            kind: MessageKind::AuthResponse {
+                success: true,
+                reason: None,
+            },
+        };
+        assert!(req.matches(&res));
+        let other = Message {
+            id: Uuid::new_v4(),
+            kind: MessageKind::Pong,
+        };
+        assert!(!req.matches(&other));
+    }
+
+    #[test]
+    fn test_authentication_flow() {
+        let req = Message {
+            id: Uuid::new_v4(),
+            kind: MessageKind::AuthRequest {
+                key: Some("secret".into()),
+            },
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("auth_request"));
+        let de: Message = serde_json::from_str(&json).unwrap();
+        if let MessageKind::AuthRequest { key } = de.kind {
+            assert_eq!(key.as_deref(), Some("secret"));
+        } else {
+            panic!("wrong variant");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `uuid` crate for request IDs
- define protocol message types and serialization
- export protocol module
- add unit tests for serialization, request id matching, and auth flow

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685bbde0987883329918126288ef6acb