### PR TITLE
Implement WebSocket server

### DIFF
--- a/ghostwriter/Cargo.lock
+++ b/ghostwriter/Cargo.lock
@@ -540,6 +540,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +571,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -576,6 +588,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -599,9 +622,11 @@ dependencies = [
  "crossterm 0.29.0",
  "env_logger",
  "fs4",
+ "futures-util",
  "log",
  "memmap2",
  "notify",
+ "rand 0.8.5",
  "ratatui",
  "serde",
  "serde_json",
@@ -1016,12 +1041,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1039,6 +1085,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
 
 [[package]]
 name = "rand_core"
@@ -1046,7 +1095,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -1360,7 +1409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
  "windows-sys 0.59.0",
@@ -1436,7 +1485,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.1",
  "sha1",
  "thiserror",
  "utf-8",
@@ -1501,7 +1550,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
  "js-sys",
  "serde",
  "wasm-bindgen",

--- a/ghostwriter/Cargo.toml
+++ b/ghostwriter/Cargo.toml
@@ -15,10 +15,12 @@ ratatui = "0.29.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 uuid = { version = "1.17.0", features = ["serde", "v4"] }
-tokio = { version = "1.45.1", features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { version = "1.45.1", features = ["rt", "rt-multi-thread", "macros", "time"] }
 tokio-tungstenite = "0.27.0"
 tempfile = "3.10.1"
 fs4 = "0.13.1"
+futures-util = "0.3"
+rand = "0.8"
 
 [dev-dependencies]
 serial_test = "3.2.0"

--- a/ghostwriter/src/error.rs
+++ b/ghostwriter/src/error.rs
@@ -56,6 +56,12 @@ impl From<notify::Error> for GhostwriterError {
     }
 }
 
+impl From<serde_json::Error> for GhostwriterError {
+    fn from(err: serde_json::Error) -> Self {
+        GhostwriterError::InvalidArgument(err.to_string())
+    }
+}
+
 /// Error type carrying additional context string.
 #[derive(Debug)]
 pub struct ContextualError {

--- a/ghostwriter/src/files/workspace.rs
+++ b/ghostwriter/src/files/workspace.rs
@@ -7,7 +7,9 @@ use std::path::{Path, PathBuf};
 use crate::error::{GhostwriterError, Result};
 
 /// File or directory entry information
-#[derive(Debug, Clone, PartialEq, Eq)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DirEntryInfo {
     pub name: String,
     pub is_dir: bool,

--- a/ghostwriter/src/network/mod.rs
+++ b/ghostwriter/src/network/mod.rs
@@ -1,4 +1,5 @@
 pub mod protocol;
+pub mod server;
 
 /// Placeholder network entry point.
 pub fn hello_network() {

--- a/ghostwriter/src/network/protocol.rs
+++ b/ghostwriter/src/network/protocol.rs
@@ -1,4 +1,6 @@
 use serde::{Deserialize, Serialize};
+
+use crate::files::workspace::DirEntryInfo;
 use uuid::Uuid;
 
 /// Represents a protocol message exchanged over WebSockets.
@@ -36,6 +38,36 @@ pub enum MessageKind {
     Pong,
     /// Error message with human readable context.
     Error { context: String },
+    /// Request to read a file within the workspace.
+    FileReadRequest { path: String },
+    /// Response containing file data if successful.
+    FileReadResponse {
+        success: bool,
+        data: Option<Vec<u8>>,
+        reason: Option<String>,
+    },
+    /// Request to write data to a file.
+    FileWriteRequest { path: String, data: Vec<u8> },
+    /// Response to a file write request.
+    FileWriteResponse {
+        success: bool,
+        reason: Option<String>,
+    },
+    /// Request directory listing.
+    DirListRequest { path: String },
+    /// Response with directory entries.
+    DirListResponse {
+        entries: Option<Vec<DirEntryInfo>>,
+        reason: Option<String>,
+    },
+    /// Request to lock a file.
+    LockRequest { path: String },
+    /// Response to lock request.
+    LockResponse {
+        success: bool,
+        readonly: bool,
+        reason: Option<String>,
+    },
 }
 
 #[cfg(test)]

--- a/ghostwriter/src/network/server.rs
+++ b/ghostwriter/src/network/server.rs
@@ -1,0 +1,602 @@
+// WebSocket server implementation
+
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use argon2::{
+    Argon2,
+    password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
+};
+use futures_util::{SinkExt, StreamExt};
+use rand::rngs::OsRng;
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::{accept_async, tungstenite::Message as WsMessage};
+use uuid::Uuid;
+
+use crate::error::{GhostwriterError, Result};
+use crate::files::file_lock::FileLock;
+use crate::files::file_manager::{FileContents, FileManager};
+use crate::files::workspace::WorkspaceManager;
+use crate::network::protocol::{Message, MessageKind};
+
+#[allow(dead_code)]
+pub struct GhostwriterServer {
+    listener: TcpListener,
+    ws: WorkspaceManager,
+    pass_hash: Option<String>,
+    client_active: Arc<std::sync::atomic::AtomicBool>,
+    lock: Arc<Mutex<Option<FileLock>>>,
+}
+
+#[allow(dead_code)]
+impl GhostwriterServer {
+    pub async fn bind(
+        addr: SocketAddr,
+        ws: WorkspaceManager,
+        pass: Option<String>,
+    ) -> Result<Self> {
+        let listener = TcpListener::bind(addr).await?;
+        let pass_hash = if let Some(p) = pass {
+            let salt = SaltString::generate(&mut OsRng);
+            let hash = Argon2::default()
+                .hash_password(p.as_bytes(), &salt)
+                .map_err(|e| GhostwriterError::InvalidArgument(e.to_string()))?
+                .to_string();
+            Some(hash)
+        } else {
+            None
+        };
+        Ok(Self {
+            listener,
+            ws,
+            pass_hash,
+            client_active: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            lock: Arc::new(Mutex::new(None)),
+        })
+    }
+
+    pub fn local_addr(&self) -> Result<SocketAddr> {
+        Ok(self.listener.local_addr()?)
+    }
+
+    pub async fn run(self) -> Result<()> {
+        loop {
+            let (stream, _) = self.listener.accept().await?;
+            if self.client_active.load(std::sync::atomic::Ordering::SeqCst) {
+                let mut ws = accept_async(stream).await?;
+                let err = Message {
+                    id: Uuid::new_v4(),
+                    kind: MessageKind::Error {
+                        context: "server busy".into(),
+                    },
+                };
+                ws.send(WsMessage::Text(serde_json::to_string(&err).unwrap().into()))
+                    .await?;
+                let _ = ws.close(None).await;
+                continue;
+            }
+            self.client_active
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            let ws_man = self.ws.clone();
+            let lock = self.lock.clone();
+            let pass = self.pass_hash.clone();
+            let active = self.client_active.clone();
+            tokio::spawn(async move {
+                let res = handle_client(stream, ws_man, lock, pass).await;
+                active.store(false, std::sync::atomic::Ordering::SeqCst);
+                if let Err(e) = res {
+                    eprintln!("client error: {e}");
+                }
+            });
+        }
+    }
+}
+
+fn resolve_existing(ws: &WorkspaceManager, path: &Path) -> Result<PathBuf> {
+    let joined = if path.is_absolute() {
+        PathBuf::from(path)
+    } else {
+        ws.root().join(path)
+    };
+    let canonical = joined.canonicalize()?;
+    if !canonical.starts_with(ws.root()) {
+        return Err(GhostwriterError::InvalidArgument(
+            "path outside workspace".into(),
+        ));
+    }
+    Ok(canonical)
+}
+
+fn resolve_new(ws: &WorkspaceManager, path: &Path) -> Result<PathBuf> {
+    let joined = if path.is_absolute() {
+        PathBuf::from(path)
+    } else {
+        ws.root().join(path)
+    };
+    let parent = joined
+        .parent()
+        .ok_or_else(|| GhostwriterError::InvalidArgument("invalid path".into()))?;
+    let canonical_parent = parent.canonicalize()?;
+    if !canonical_parent.starts_with(ws.root()) {
+        return Err(GhostwriterError::InvalidArgument(
+            "path outside workspace".into(),
+        ));
+    }
+    Ok(canonical_parent.join(joined.file_name().unwrap()))
+}
+
+async fn handle_client(
+    stream: TcpStream,
+    ws: WorkspaceManager,
+    lock: Arc<Mutex<Option<FileLock>>>,
+    pass_hash: Option<String>,
+) -> Result<()> {
+    let mut ws_stream = accept_async(stream).await?;
+    if let Some(hash) = pass_hash {
+        let msg = ws_stream
+            .next()
+            .await
+            .ok_or_else(|| GhostwriterError::Network("no auth".into()))??;
+        let txt = msg.into_text()?;
+        let req: Message = serde_json::from_str(&txt)?;
+        let key = match req.kind {
+            MessageKind::AuthRequest { key } => key.unwrap_or_default(),
+            _ => String::new(),
+        };
+        let parsed = PasswordHash::new(&hash).unwrap();
+        let valid = Argon2::default()
+            .verify_password(key.as_bytes(), &parsed)
+            .is_ok();
+        let resp = Message {
+            id: req.id,
+            kind: MessageKind::AuthResponse {
+                success: valid,
+                reason: if valid {
+                    None
+                } else {
+                    Some("invalid key".into())
+                },
+            },
+        };
+        ws_stream
+            .send(WsMessage::Text(
+                serde_json::to_string(&resp).unwrap().into(),
+            ))
+            .await?;
+        if !valid {
+            let _ = ws_stream.close(None).await;
+            return Ok(());
+        }
+    } else if let Some(msg) = ws_stream.next().await {
+        let msg = msg?;
+        if msg.is_text() {
+            let txt = msg.into_text()?;
+            if let Ok(req) = serde_json::from_str::<Message>(&txt) {
+                if matches!(req.kind, MessageKind::AuthRequest { .. }) {
+                    let resp = Message {
+                        id: req.id,
+                        kind: MessageKind::AuthResponse {
+                            success: true,
+                            reason: None,
+                        },
+                    };
+                    ws_stream
+                        .send(WsMessage::Text(
+                            serde_json::to_string(&resp).unwrap().into(),
+                        ))
+                        .await?;
+                }
+            }
+        } else if msg.is_close() {
+            let _ = ws_stream.close(None).await;
+            return Ok(());
+        }
+    }
+
+    while let Some(msg) = ws_stream.next().await {
+        let msg = msg?;
+        if msg.is_text() {
+            let txt = msg.into_text()?;
+            let req: Message = serde_json::from_str(&txt)?;
+            match req.kind {
+                MessageKind::Ping => {
+                    let resp = Message {
+                        id: req.id,
+                        kind: MessageKind::Pong,
+                    };
+                    ws_stream
+                        .send(WsMessage::Text(
+                            serde_json::to_string(&resp).unwrap().into(),
+                        ))
+                        .await?;
+                }
+                MessageKind::FileReadRequest { path } => {
+                    let full = resolve_existing(&ws, Path::new(&path));
+                    let resp = match full.and_then(|p| FileManager::read(&p)) {
+                        Ok(FileContents::InMemory(data)) => Message {
+                            id: req.id,
+                            kind: MessageKind::FileReadResponse {
+                                success: true,
+                                data: Some(data),
+                                reason: None,
+                            },
+                        },
+                        Ok(FileContents::Mapped(m)) => Message {
+                            id: req.id,
+                            kind: MessageKind::FileReadResponse {
+                                success: true,
+                                data: Some(m.as_ref().to_vec()),
+                                reason: None,
+                            },
+                        },
+                        Err(e) => Message {
+                            id: req.id,
+                            kind: MessageKind::FileReadResponse {
+                                success: false,
+                                data: None,
+                                reason: Some(e.to_string()),
+                            },
+                        },
+                    };
+                    ws_stream
+                        .send(WsMessage::Text(
+                            serde_json::to_string(&resp).unwrap().into(),
+                        ))
+                        .await?;
+                }
+                MessageKind::FileWriteRequest { path, data } => {
+                    let full = resolve_new(&ws, Path::new(&path));
+                    let res = full.and_then(|p| FileManager::atomic_write(&p, &data));
+                    let resp = match res {
+                        Ok(_) => Message {
+                            id: req.id,
+                            kind: MessageKind::FileWriteResponse {
+                                success: true,
+                                reason: None,
+                            },
+                        },
+                        Err(e) => Message {
+                            id: req.id,
+                            kind: MessageKind::FileWriteResponse {
+                                success: false,
+                                reason: Some(e.to_string()),
+                            },
+                        },
+                    };
+                    ws_stream
+                        .send(WsMessage::Text(
+                            serde_json::to_string(&resp).unwrap().into(),
+                        ))
+                        .await?;
+                }
+                MessageKind::DirListRequest { path } => {
+                    let resp = match ws.list_dir(Path::new(&path)) {
+                        Ok(entries) => Message {
+                            id: req.id,
+                            kind: MessageKind::DirListResponse {
+                                entries: Some(entries),
+                                reason: None,
+                            },
+                        },
+                        Err(e) => Message {
+                            id: req.id,
+                            kind: MessageKind::DirListResponse {
+                                entries: None,
+                                reason: Some(e.to_string()),
+                            },
+                        },
+                    };
+                    ws_stream
+                        .send(WsMessage::Text(
+                            serde_json::to_string(&resp).unwrap().into(),
+                        ))
+                        .await?;
+                }
+                MessageKind::LockRequest { path } => {
+                    let resp_json;
+                    {
+                        let mut guard = lock.lock().unwrap();
+                        resp_json = if guard.is_some() {
+                            let resp = Message {
+                                id: req.id,
+                                kind: MessageKind::LockResponse {
+                                    success: false,
+                                    readonly: false,
+                                    reason: Some("already locked".into()),
+                                },
+                            };
+                            serde_json::to_string(&resp).unwrap()
+                        } else {
+                            let full = resolve_existing(&ws, Path::new(&path));
+                            let res =
+                                full.and_then(|p| FileLock::acquire(&p, Duration::from_secs(5)));
+                            let resp = match res {
+                                Ok(l) => {
+                                    *guard = Some(l);
+                                    let readonly = guard.as_ref().unwrap().readonly();
+                                    Message {
+                                        id: req.id,
+                                        kind: MessageKind::LockResponse {
+                                            success: true,
+                                            readonly,
+                                            reason: None,
+                                        },
+                                    }
+                                }
+                                Err(e) => Message {
+                                    id: req.id,
+                                    kind: MessageKind::LockResponse {
+                                        success: false,
+                                        readonly: false,
+                                        reason: Some(e.to_string()),
+                                    },
+                                },
+                            };
+                            serde_json::to_string(&resp).unwrap()
+                        };
+                    }
+                    ws_stream.send(WsMessage::Text(resp_json.into())).await?;
+                }
+                _ => {}
+            }
+        } else if msg.is_close() {
+            let _ = ws_stream.close(None).await;
+            break;
+        }
+    }
+    let mut guard = lock.lock().unwrap();
+    *guard = None;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+    use tokio_tungstenite::connect_async;
+
+    #[tokio::test]
+    async fn test_single_client_enforcement() {
+        let dir = tempdir().unwrap();
+        let ws = WorkspaceManager::new(dir.path().to_path_buf()).unwrap();
+        std::fs::write(dir.path().join("file.txt"), b"data").unwrap();
+        let server = GhostwriterServer::bind("127.0.0.1:0".parse().unwrap(), ws, None)
+            .await
+            .unwrap();
+        let addr = server.local_addr().unwrap();
+        let handle = tokio::spawn(server.run());
+
+        let (mut c1, _) = connect_async(format!("ws://{}", addr)).await.unwrap();
+        let auth = Message {
+            id: Uuid::new_v4(),
+            kind: MessageKind::AuthRequest { key: None },
+        };
+        c1.send(WsMessage::Text(
+            serde_json::to_string(&auth).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+        let _ = c1.next().await.unwrap().unwrap();
+
+        let (mut c2, _) = connect_async(format!("ws://{}", addr)).await.unwrap();
+        let resp = c2.next().await.unwrap().unwrap();
+        let msg: Message = serde_json::from_str(&resp.into_text().unwrap()).unwrap();
+        assert!(matches!(msg.kind, MessageKind::Error { .. }));
+        c1.close(None).await.unwrap();
+        handle.abort();
+        let _ = handle.await;
+    }
+
+    #[tokio::test]
+    async fn test_authentication_flow() {
+        let dir = tempdir().unwrap();
+        let ws = WorkspaceManager::new(dir.path().to_path_buf()).unwrap();
+        let server =
+            GhostwriterServer::bind("127.0.0.1:0".parse().unwrap(), ws, Some("secret".into()))
+                .await
+                .unwrap();
+        let addr = server.local_addr().unwrap();
+        let handle = tokio::spawn(server.run());
+
+        let (mut wrong, _) = connect_async(format!("ws://{}", addr)).await.unwrap();
+        let req = Message {
+            id: Uuid::new_v4(),
+            kind: MessageKind::AuthRequest {
+                key: Some("bad".into()),
+            },
+        };
+        wrong
+            .send(WsMessage::Text(serde_json::to_string(&req).unwrap().into()))
+            .await
+            .unwrap();
+        let resp = wrong.next().await.unwrap().unwrap();
+        let msg: Message = serde_json::from_str(&resp.into_text().unwrap()).unwrap();
+        if let MessageKind::AuthResponse { success, .. } = msg.kind {
+            assert!(!success);
+        }
+
+        let (mut okc, _) = connect_async(format!("ws://{}", addr)).await.unwrap();
+        let req = Message {
+            id: Uuid::new_v4(),
+            kind: MessageKind::AuthRequest {
+                key: Some("secret".into()),
+            },
+        };
+        okc.send(WsMessage::Text(serde_json::to_string(&req).unwrap().into()))
+            .await
+            .unwrap();
+        let resp = okc.next().await.unwrap().unwrap();
+        let msg: Message = serde_json::from_str(&resp.into_text().unwrap()).unwrap();
+        if let MessageKind::AuthResponse { success, .. } = msg.kind {
+            assert!(success);
+        }
+        wrong.close(None).await.unwrap();
+        okc.close(None).await.unwrap();
+        handle.abort();
+        let _ = handle.await;
+    }
+
+    #[tokio::test]
+    async fn test_file_operations() {
+        let dir = tempdir().unwrap();
+        let ws = WorkspaceManager::new(dir.path().to_path_buf()).unwrap();
+        let server = GhostwriterServer::bind("127.0.0.1:0".parse().unwrap(), ws, None)
+            .await
+            .unwrap();
+        let addr = server.local_addr().unwrap();
+        let handle = tokio::spawn(server.run());
+
+        let (mut client, _) = connect_async(format!("ws://{}", addr)).await.unwrap();
+        let auth = Message {
+            id: Uuid::new_v4(),
+            kind: MessageKind::AuthRequest { key: None },
+        };
+        client
+            .send(WsMessage::Text(
+                serde_json::to_string(&auth).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+        let _ = client.next().await.unwrap().unwrap();
+
+        let write = Message {
+            id: Uuid::new_v4(),
+            kind: MessageKind::FileWriteRequest {
+                path: "file.txt".into(),
+                data: b"hello".to_vec(),
+            },
+        };
+        client
+            .send(WsMessage::Text(
+                serde_json::to_string(&write).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+        let resp = client.next().await.unwrap().unwrap();
+        let msg: Message = serde_json::from_str(&resp.into_text().unwrap()).unwrap();
+        assert!(matches!(
+            msg.kind,
+            MessageKind::FileWriteResponse { success: true, .. }
+        ));
+
+        let read = Message {
+            id: Uuid::new_v4(),
+            kind: MessageKind::FileReadRequest {
+                path: "file.txt".into(),
+            },
+        };
+        client
+            .send(WsMessage::Text(
+                serde_json::to_string(&read).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+        let resp = client.next().await.unwrap().unwrap();
+        let msg: Message = serde_json::from_str(&resp.into_text().unwrap()).unwrap();
+        if let MessageKind::FileReadResponse { success, data, .. } = msg.kind {
+            assert!(success);
+            assert_eq!(data.unwrap(), b"hello".to_vec());
+        }
+
+        let list = Message {
+            id: Uuid::new_v4(),
+            kind: MessageKind::DirListRequest { path: ".".into() },
+        };
+        client
+            .send(WsMessage::Text(
+                serde_json::to_string(&list).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+        let resp = client.next().await.unwrap().unwrap();
+        let msg: Message = serde_json::from_str(&resp.into_text().unwrap()).unwrap();
+        if let MessageKind::DirListResponse { entries, .. } = msg.kind {
+            assert_eq!(entries.unwrap().len(), 1);
+        }
+
+        let lock_msg = Message {
+            id: Uuid::new_v4(),
+            kind: MessageKind::LockRequest {
+                path: "file.txt".into(),
+            },
+        };
+        client
+            .send(WsMessage::Text(
+                serde_json::to_string(&lock_msg).unwrap().into(),
+            ))
+            .await
+            .unwrap();
+        let resp = client.next().await.unwrap().unwrap();
+        let msg: Message = serde_json::from_str(&resp.into_text().unwrap()).unwrap();
+        assert!(matches!(
+            msg.kind,
+            MessageKind::LockResponse { success: true, .. }
+        ));
+        client.close(None).await.unwrap();
+        let _ = client.close(None).await;
+        handle.abort();
+        let _ = handle.await;
+    }
+
+    #[tokio::test]
+    async fn test_automatic_lock_cleanup() {
+        let dir = tempdir().unwrap();
+        let ws = WorkspaceManager::new(dir.path().to_path_buf()).unwrap();
+        std::fs::write(dir.path().join("file.txt"), b"data").unwrap();
+        let server = GhostwriterServer::bind("127.0.0.1:0".parse().unwrap(), ws, None)
+            .await
+            .unwrap();
+        let addr = server.local_addr().unwrap();
+        let handle = tokio::spawn(server.run());
+
+        let (mut c1, _) = connect_async(format!("ws://{}", addr)).await.unwrap();
+        let auth = Message {
+            id: Uuid::new_v4(),
+            kind: MessageKind::AuthRequest { key: None },
+        };
+        c1.send(WsMessage::Text(
+            serde_json::to_string(&auth).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+        let _ = c1.next().await.unwrap().unwrap();
+        let lock_msg = Message {
+            id: Uuid::new_v4(),
+            kind: MessageKind::LockRequest {
+                path: "file.txt".into(),
+            },
+        };
+        c1.send(WsMessage::Text(
+            serde_json::to_string(&lock_msg).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+        let _ = c1.next().await.unwrap().unwrap();
+        c1.close(None).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let (mut c2, _) = connect_async(format!("ws://{}", addr)).await.unwrap();
+        c2.send(WsMessage::Text(
+            serde_json::to_string(&auth).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+        let _ = c2.next().await.unwrap().unwrap();
+        c2.send(WsMessage::Text(
+            serde_json::to_string(&lock_msg).unwrap().into(),
+        ))
+        .await
+        .unwrap();
+        let resp = c2.next().await.unwrap().unwrap();
+        let msg: Message = serde_json::from_str(&resp.into_text().unwrap()).unwrap();
+        assert!(matches!(
+            msg.kind,
+            MessageKind::LockResponse { success: true, .. }
+        ));
+        c2.close(None).await.unwrap();
+        handle.abort();
+        let _ = handle.await;
+    }
+}


### PR DESCRIPTION
## Summary
- add single-client WebSocket server
- implement file operations and lock handling
- support graceful disconnects and cleanup
- add comprehensive server tests

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685bc0db04a08332be2b73c9e5e8d283