### PR TITLE
Verify Phase 5 WebSockets implementation

### DIFF
--- a/ghostwriter/src/main.rs
+++ b/ghostwriter/src/main.rs
@@ -57,7 +57,6 @@ fn main() {
         // Placeholder module calls
         app::hello_app();
         editor::hello_editor();
-        network::hello_network();
     }
 }
 
@@ -135,7 +134,11 @@ mod tests {
         app::hello_app();
         editor::hello_editor();
         let _ = files::file_manager::FileManager::is_binary(b"test");
-        network::hello_network();
+        let msg = network::protocol::Message {
+            id: uuid::Uuid::nil(),
+            kind: network::protocol::MessageKind::Ping,
+        };
+        let _ = serde_json::to_string(&msg).unwrap();
         assert!(true, "Module functions callable");
     }
 

--- a/ghostwriter/src/network/mod.rs
+++ b/ghostwriter/src/network/mod.rs
@@ -2,8 +2,3 @@ pub mod client;
 pub mod internal;
 pub mod protocol;
 pub mod server;
-
-/// Placeholder network entry point.
-pub fn hello_network() {
-    println!("Hello from network module!");
-}


### PR DESCRIPTION
## Summary
- remove leftover network::hello_network placeholder
- adjust `test_modules_callable` to exercise protocol module

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685c2771b8fc8332aea75bdf1a8c8c66