### PR TITLE
Implement file history stack

### DIFF
--- a/ghostwriter/src/editor/undo.rs
+++ b/ghostwriter/src/editor/undo.rs
@@ -17,6 +17,7 @@ pub struct UndoRecord {
     pub after: Cursor,
 }
 
+#[derive(Debug)]
 pub struct UndoStack {
     limit: usize,
     entries: Vec<UndoRecord>,

--- a/ghostwriter/src/files/file_history.rs
+++ b/ghostwriter/src/files/file_history.rs
@@ -1,0 +1,155 @@
+// File history stack implementation
+#![allow(dead_code)]
+
+use std::path::PathBuf;
+
+use crate::editor::{cursor::Cursor, undo::UndoStack};
+
+/// State of an open file including editor context.
+#[derive(Debug)]
+pub struct FileState {
+    pub path: PathBuf,
+    pub cursor: Cursor,
+    pub scroll_x: u16,
+    pub scroll_y: u16,
+    pub undo: UndoStack,
+}
+
+/// Browser-like file history with branching support.
+#[derive(Debug, Default)]
+pub struct FileHistory {
+    entries: Vec<FileState>,
+    position: usize,
+}
+
+impl FileHistory {
+    /// Create an empty file history.
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            position: 0,
+        }
+    }
+
+    /// Push a new file state onto the history, truncating any forward entries.
+    pub fn push(&mut self, state: FileState) {
+        if self.position < self.entries.len() {
+            self.entries.truncate(self.position + 1);
+        }
+        self.entries.push(state);
+        self.position = self.entries.len() - 1;
+    }
+
+    /// Move backward in history, returning the new current state.
+    pub fn back(&mut self) -> Option<&FileState> {
+        if self.position == 0 || self.entries.is_empty() {
+            return None;
+        }
+        self.position -= 1;
+        self.entries.get(self.position)
+    }
+
+    /// Move forward in history, returning the new current state.
+    pub fn forward(&mut self) -> Option<&FileState> {
+        if self.position + 1 >= self.entries.len() {
+            return None;
+        }
+        self.position += 1;
+        self.entries.get(self.position)
+    }
+
+    /// Get the current file state.
+    pub fn current(&self) -> Option<&FileState> {
+        self.entries.get(self.position)
+    }
+
+    /// Number of entries stored.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether history is empty.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::editor::rope::Rope;
+    use crate::editor::undo::{UndoOperation, UndoRecord};
+
+    fn sample_state(path: &str) -> FileState {
+        let mut undo = UndoStack::new(10);
+        let mut rope = Rope::from_str("hi");
+        let cursor = Cursor::new();
+        rope.insert(2, "!");
+        undo.push(UndoRecord {
+            op: UndoOperation::Insert {
+                index: 2,
+                text: "!".into(),
+            },
+            before: cursor,
+            after: cursor,
+        });
+        FileState {
+            path: PathBuf::from(path),
+            cursor,
+            scroll_x: 0,
+            scroll_y: 0,
+            undo,
+        }
+    }
+
+    #[test]
+    fn test_history_stack_operations() {
+        let mut hist = FileHistory::new();
+        hist.push(sample_state("a"));
+        hist.push(sample_state("b"));
+        assert_eq!(hist.current().unwrap().path, PathBuf::from("b"));
+        hist.back();
+        assert_eq!(hist.current().unwrap().path, PathBuf::from("a"));
+        hist.forward();
+        assert_eq!(hist.current().unwrap().path, PathBuf::from("b"));
+    }
+
+    #[test]
+    fn test_branching_behavior() {
+        let mut hist = FileHistory::new();
+        hist.push(sample_state("a"));
+        hist.push(sample_state("b"));
+        hist.back();
+        hist.push(sample_state("c"));
+        assert_eq!(hist.len(), 2);
+        assert_eq!(hist.current().unwrap().path, PathBuf::from("c"));
+        assert!(hist.forward().is_none());
+        hist.back();
+        assert_eq!(hist.current().unwrap().path, PathBuf::from("a"));
+        hist.forward();
+        assert_eq!(hist.current().unwrap().path, PathBuf::from("c"));
+    }
+
+    #[test]
+    fn test_state_persistence() {
+        let mut hist = FileHistory::new();
+        let mut state = sample_state("a");
+        state.cursor.line = 5;
+        state.scroll_x = 2;
+        hist.push(state);
+        assert_eq!(hist.current().unwrap().cursor.line, 5);
+        hist.back();
+        // Should still be None because there was only one entry
+        assert!(hist.current().is_some());
+        assert_eq!(hist.current().unwrap().cursor.line, 5);
+    }
+
+    #[test]
+    fn test_unlimited_history() {
+        let mut hist = FileHistory::new();
+        for i in 0..1000 {
+            hist.push(sample_state(&format!("{i}")));
+        }
+        assert_eq!(hist.len(), 1000);
+    }
+}

--- a/ghostwriter/src/files/mod.rs
+++ b/ghostwriter/src/files/mod.rs
@@ -1,5 +1,6 @@
 // files module
 
+pub mod file_history;
 pub mod file_lock;
 pub mod file_manager;
 pub mod file_watcher;


### PR DESCRIPTION
## Summary
- add `FileHistory` module with push/back/forward logic
- expose file history in `files::mod`
- derive `Debug` for `UndoStack`
- test history stack behavior

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685c3e7c04d48332b9ba6d12bc752033