### PR TITLE
Add boundary and error handling tests for Phase 6 features

### DIFF
--- a/ghostwriter/src/editor/search.rs
+++ b/ghostwriter/src/editor/search.rs
@@ -155,4 +155,12 @@ mod tests {
         search.update(&rope, "foo", false, true).unwrap();
         assert_eq!(search.matches.len(), 1);
     }
+
+    #[test]
+    fn test_invalid_regex_error() {
+        let rope = Rope::from_str("content");
+        let mut search = Search::new();
+        let res = search.update(&rope, "(", true, true);
+        assert!(res.is_err(), "invalid regex should return error");
+    }
 }

--- a/ghostwriter/src/files/file_history.rs
+++ b/ghostwriter/src/files/file_history.rs
@@ -152,4 +152,21 @@ mod tests {
         }
         assert_eq!(hist.len(), 1000);
     }
+
+    #[test]
+    fn test_history_boundaries() {
+        let mut hist = FileHistory::new();
+        assert!(hist.back().is_none());
+        assert!(hist.forward().is_none());
+
+        hist.push(sample_state("a"));
+        assert!(hist.back().is_none());
+        assert!(hist.forward().is_none());
+
+        hist.push(sample_state("b"));
+        hist.back();
+        assert!(hist.back().is_none());
+        hist.forward();
+        assert!(hist.forward().is_none());
+    }
 }

--- a/ghostwriter/src/files/search.rs
+++ b/ghostwriter/src/files/search.rs
@@ -131,4 +131,13 @@ mod tests {
         let res = ws.search("match", false, true, 5).unwrap();
         assert_eq!(res.len(), 5);
     }
+
+    #[test]
+    fn test_invalid_regex_error() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("e.txt"), "text").unwrap();
+        let ws = WorkspaceManager::new(dir.path().to_path_buf()).unwrap();
+        let res = ws.search("(", true, true, 1000);
+        assert!(res.is_err(), "invalid regex should return error");
+    }
 }


### PR DESCRIPTION
## Summary
- expand unit tests for `Search` and cross-file search to cover invalid regex cases
- add boundary checks in `FileHistory` tests

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685c48fac6b48332a384dece4de33ea0