### PR TITLE
Implement missing Stage 7 test

### DIFF
--- a/ghostwriter/src/files/file_manager.rs
+++ b/ghostwriter/src/files/file_manager.rs
@@ -167,4 +167,12 @@ mod tests {
         }
         assert_eq!(out, data);
     }
+
+    #[test]
+    fn test_file_system_error_handling() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nope").join("file.txt");
+        let res = FileManager::atomic_write(&path, b"data");
+        assert!(res.is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- add unit test for filesystem error case in `FileManager`

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685c5b194de48332a830c31212bdd8eb