### PR TITLE
Implement security audit tests

### DIFF
--- a/ghostwriter/src/files/workspace.rs
+++ b/ghostwriter/src/files/workspace.rs
@@ -57,6 +57,7 @@ impl WorkspaceManager {
 
     /// Resolve an existing path within the workspace.
     fn resolve_existing(&self, path: &Path) -> Result<PathBuf> {
+        crate::security::sanitize_path(path)?;
         let joined = if path.is_absolute() {
             PathBuf::from(path)
         } else {
@@ -73,6 +74,7 @@ impl WorkspaceManager {
 
     /// Resolve a new path for creation within the workspace.
     fn resolve_new(&self, path: &Path) -> Result<PathBuf> {
+        crate::security::sanitize_path(path)?;
         let joined = if path.is_absolute() {
             PathBuf::from(path)
         } else {

--- a/ghostwriter/src/lib.rs
+++ b/ghostwriter/src/lib.rs
@@ -10,5 +10,6 @@ pub mod editor;
 pub mod error;
 pub mod files;
 pub mod network;
+pub mod security;
 pub mod state;
 pub mod ui;

--- a/ghostwriter/src/main.rs
+++ b/ghostwriter/src/main.rs
@@ -4,6 +4,7 @@ mod editor;
 mod error;
 mod files;
 mod network;
+mod security;
 mod state;
 mod ui;
 

--- a/ghostwriter/src/network/server.rs
+++ b/ghostwriter/src/network/server.rs
@@ -95,6 +95,7 @@ impl GhostwriterServer {
 }
 
 fn resolve_existing(ws: &WorkspaceManager, path: &Path) -> Result<PathBuf> {
+    crate::security::sanitize_path(path)?;
     let joined = if path.is_absolute() {
         PathBuf::from(path)
     } else {
@@ -110,6 +111,7 @@ fn resolve_existing(ws: &WorkspaceManager, path: &Path) -> Result<PathBuf> {
 }
 
 fn resolve_new(ws: &WorkspaceManager, path: &Path) -> Result<PathBuf> {
+    crate::security::sanitize_path(path)?;
     let joined = if path.is_absolute() {
         PathBuf::from(path)
     } else {

--- a/ghostwriter/src/security.rs
+++ b/ghostwriter/src/security.rs
@@ -1,0 +1,44 @@
+use std::path::Path;
+
+use crate::error::{GhostwriterError, Result};
+
+/// Sanitize a path input to prevent injection and traversal attacks.
+pub fn sanitize_path(path: &Path) -> Result<()> {
+    let s = path.to_string_lossy();
+    if s.is_empty() {
+        return Err(GhostwriterError::InvalidArgument("empty path".into()));
+    }
+    if s.contains('\0') || s.contains('\n') || s.contains('\r') || s.contains('\t') {
+        return Err(GhostwriterError::InvalidArgument(
+            "invalid characters".into(),
+        ));
+    }
+    for part in s.split(['/', '\\'].as_ref()) {
+        if part == ".." {
+            return Err(GhostwriterError::InvalidArgument(
+                "path traversal detected".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reject_traversal() {
+        assert!(sanitize_path(Path::new("../evil")).is_err());
+    }
+
+    #[test]
+    fn test_reject_control_chars() {
+        assert!(sanitize_path(Path::new("bad\x00name")).is_err());
+    }
+
+    #[test]
+    fn test_accept_normal_path() {
+        assert!(sanitize_path(Path::new("normal.txt")).is_ok());
+    }
+}

--- a/ghostwriter/tests/security.rs
+++ b/ghostwriter/tests/security.rs
@@ -1,0 +1,108 @@
+use ghostwriter::files::workspace::WorkspaceManager;
+use ghostwriter::network::client::GhostwriterClient;
+use ghostwriter::network::protocol::MessageKind;
+use ghostwriter::network::server::GhostwriterServer;
+use serial_test::serial;
+use tokio::time::Duration;
+
+#[tokio::test]
+#[serial]
+async fn test_path_traversal_prevention() {
+    let dir = tempfile::tempdir().unwrap();
+    let ws = WorkspaceManager::new(dir.path().to_path_buf()).unwrap();
+    let server = GhostwriterServer::bind("127.0.0.1:0".parse().unwrap(), ws, None)
+        .await
+        .unwrap();
+    let addr = server.local_addr().unwrap();
+    let handle = tokio::spawn(server.run());
+
+    let mut client = GhostwriterClient::new(format!("ws://{}", addr), None).unwrap();
+    client.connect().await.unwrap();
+    let resp = client
+        .request(
+            MessageKind::FileReadRequest {
+                path: "../secret.txt".into(),
+            },
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+    if let MessageKind::FileReadResponse {
+        success, reason, ..
+    } = resp.kind
+    {
+        assert!(!success);
+        assert!(reason.is_some());
+    } else {
+        panic!("unexpected response");
+    }
+
+    handle.abort();
+    let _ = handle.await;
+}
+
+#[tokio::test]
+#[serial]
+async fn test_authentication_attack_resistance() {
+    let dir = tempfile::tempdir().unwrap();
+    let ws = WorkspaceManager::new(dir.path().to_path_buf()).unwrap();
+    let server = GhostwriterServer::bind("127.0.0.1:0".parse().unwrap(), ws, Some("pass".into()))
+        .await
+        .unwrap();
+    let addr = server.local_addr().unwrap();
+    let handle = tokio::spawn(server.run());
+
+    let mut bad = GhostwriterClient::new(format!("ws://{}", addr), Some("wrong".into())).unwrap();
+    assert!(bad.connect().await.is_err());
+
+    handle.abort();
+    let _ = handle.await;
+}
+
+#[test]
+fn test_input_sanitization() {
+    use ghostwriter::security::sanitize_path;
+    use std::path::Path;
+    assert!(sanitize_path(Path::new("../evil")).is_err());
+    assert!(sanitize_path(Path::new("good.txt")).is_ok());
+    assert!(sanitize_path(Path::new("bad\x00name")).is_err());
+}
+
+#[tokio::test]
+#[serial]
+async fn test_workspace_escape_attempts() {
+    let dir = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let link = dir.path().join("link");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(outside.path(), &link).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(outside.path(), &link).unwrap();
+    let ws = WorkspaceManager::new(dir.path().to_path_buf()).unwrap();
+    let server = GhostwriterServer::bind("127.0.0.1:0".parse().unwrap(), ws, None)
+        .await
+        .unwrap();
+    let addr = server.local_addr().unwrap();
+    let handle = tokio::spawn(server.run());
+
+    let mut client = GhostwriterClient::new(format!("ws://{}", addr), None).unwrap();
+    client.connect().await.unwrap();
+    let resp = client
+        .request(
+            MessageKind::DirListRequest {
+                path: "link".into(),
+            },
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+    if let MessageKind::DirListResponse { entries, reason } = resp.kind {
+        assert!(entries.is_none());
+        assert!(reason.is_some());
+    } else {
+        panic!("unexpected response");
+    }
+
+    handle.abort();
+    let _ = handle.await;
+}


### PR DESCRIPTION
## Summary
- add `security` module with path sanitization helpers
- integrate sanitization into workspace and server path resolution
- expose `security` module in library and binary
- create integration tests covering security audit cases

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685ceac78e9c83328af7ffb9e0ead07c