### PR TITLE
Implement performance validation tests

### DIFF
--- a/ghostwriter/Cargo.lock
+++ b/ghostwriter/Cargo.lock
@@ -652,6 +652,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "sysinfo",
  "tempfile",
  "tokio",
  "tokio-tungstenite",
@@ -1054,6 +1055,34 @@ name = "notify-types"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
 
 [[package]]
 name = "object"
@@ -1572,6 +1601,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.35.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3ffa3e4ff2b324a57f7aeb3c349656c7b127c3c189520251a648102a92496e"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,6 +1932,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1945,6 +2090,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/ghostwriter/Cargo.toml
+++ b/ghostwriter/Cargo.toml
@@ -28,6 +28,7 @@ url = "2.5.0"
 
 [dev-dependencies]
 serial_test = "3.2.0"
+sysinfo = "0.35.2"
 
 [lib]
 path = "src/lib.rs"

--- a/ghostwriter/tests/performance.rs
+++ b/ghostwriter/tests/performance.rs
@@ -1,0 +1,109 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ghostwriter::editor::{cursor::Cursor, key_handler::KeyHandler, rope::Rope};
+use ghostwriter::files::workspace::WorkspaceManager;
+use ghostwriter::network::{
+    client::GhostwriterClient, internal::InternalServer, protocol::MessageKind,
+    server::GhostwriterServer,
+};
+use serial_test::serial;
+use std::time::{Duration, Instant};
+use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
+use tempfile::tempdir;
+
+fn key(ch: char) -> KeyEvent {
+    KeyEvent::new(KeyCode::Char(ch), KeyModifiers::empty())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_startup_performance_targets() {
+    let dir = tempdir().unwrap();
+    let start = Instant::now();
+    let (server, mut client) = InternalServer::start(dir.path().to_path_buf(), None)
+        .await
+        .unwrap();
+    client.connect().await.unwrap();
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < Duration::from_millis(50),
+        "startup took {:?}",
+        elapsed
+    );
+    drop(client);
+    drop(server);
+}
+
+#[test]
+fn test_edit_operation_latency() {
+    let mut rope = Rope::new();
+    let mut cursor = Cursor::new();
+    let mut handler = KeyHandler::new();
+    let mut sel = None;
+    let start = Instant::now();
+    for _ in 0..100 {
+        handler.handle(key('a'), &mut rope, &mut cursor, &mut sel);
+    }
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < Duration::from_millis(10),
+        "edit latency {:?}",
+        elapsed
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_memory_usage_limits() {
+    let pid = Pid::from_u32(std::process::id());
+    let mut sys = System::new();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[pid]),
+        false,
+        ProcessRefreshKind::everything(),
+    );
+    let before = sys.process(pid).unwrap().memory();
+    let chunk = "a".repeat(1024 * 1024); // 1MB
+    let mut rope = Rope::new();
+    for _ in 0..50 {
+        rope.append(&chunk);
+    }
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[pid]),
+        false,
+        ProcessRefreshKind::everything(),
+    );
+    let after = sys.process(pid).unwrap().memory();
+    assert!(
+        after - before < 100 * 1024 * 1024,
+        "memory usage {} bytes",
+        after - before
+    );
+    drop(rope);
+}
+
+#[tokio::test]
+#[serial]
+async fn test_network_operation_performance() {
+    let dir = tempdir().unwrap();
+    let ws = WorkspaceManager::new(dir.path().to_path_buf()).unwrap();
+    let server = GhostwriterServer::bind("127.0.0.1:0".parse().unwrap(), ws, None)
+        .await
+        .unwrap();
+    let addr = server.local_addr().unwrap();
+    let handle = tokio::spawn(server.run());
+    let mut client = GhostwriterClient::new(format!("ws://{}", addr), None).unwrap();
+    client.connect().await.unwrap();
+    let start = Instant::now();
+    client
+        .request(MessageKind::Ping, Duration::from_secs(1))
+        .await
+        .unwrap();
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < Duration::from_millis(100),
+        "network latency {:?}",
+        elapsed
+    );
+    handle.abort();
+    let _ = handle.await;
+}


### PR DESCRIPTION
## Summary
- add `sysinfo` dev-dependency for resource measurement
- implement performance validation tests for startup time, edit latency, memory usage and network performance

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo test --test performance`


------
https://chatgpt.com/codex/tasks/task_e_685cf0e883108332827df007e1851853