### PR TITLE
Implement basic interactive app runner

### DIFF
--- a/ghostwriter/src/app/mod.rs
+++ b/ghostwriter/src/app/mod.rs
@@ -1,4 +1,147 @@
-// app module
-pub fn hello_app() {
-    println!("Hello from app module!");
+use std::path::PathBuf;
+
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use ratatui::prelude::*;
+
+use crate::editor::{cursor::Cursor, key_handler::KeyHandler, rope::Rope, selection::Selection};
+use crate::error::Result;
+use crate::files::file_manager::{FileContents, FileManager};
+use crate::ui::{
+    TerminalUI,
+    editor_widget::{EditorState, EditorWidget},
+    status_bar::{ConnectionStatus, LockStatus, Mode, StatusBar},
+};
+
+/// Basic application state used during editing.
+#[derive(Debug)]
+pub struct App {
+    rope: Rope,
+    cursor: Cursor,
+    selection: Option<Selection>,
+    dirty: bool,
+    path: PathBuf,
+    handler: KeyHandler,
+}
+
+impl App {
+    /// Open a file from disk into a new `App` instance.
+    pub fn open(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+        let contents = FileManager::read(&path)?;
+        let rope = match contents {
+            FileContents::InMemory(d) => Rope::from_bytes(&d),
+            FileContents::Mapped(m) => Rope::from_bytes(m.as_ref()),
+        };
+        Ok(Self {
+            rope,
+            cursor: Cursor::new(),
+            selection: None,
+            dirty: false,
+            path,
+            handler: KeyHandler::new(),
+        })
+    }
+
+    /// Apply a key event to the editor state.
+    pub fn handle_key(&mut self, event: KeyEvent) {
+        let before = self.rope.as_string();
+        self.handler
+            .handle(event, &mut self.rope, &mut self.cursor, &mut self.selection);
+        if self.rope.as_string() != before {
+            self.dirty = true;
+        }
+    }
+
+    /// Save the current buffer to disk.
+    pub fn save(&mut self) -> Result<()> {
+        FileManager::atomic_write(&self.path, self.rope.as_string().as_bytes())?;
+        self.dirty = false;
+        Ok(())
+    }
+
+    /// Draw the editor and status bar widgets.
+    pub fn draw<B: Backend>(&mut self, ui: &mut TerminalUI<B>) -> Result<()> {
+        let size = ui.terminal().size()?;
+        let rect = Rect::new(0, 0, size.width, size.height);
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(1)])
+            .split(rect);
+        let mut state = EditorState {
+            cursor: self.cursor,
+            selection: self.selection.clone(),
+            scroll_x: 0,
+            scroll_y: 0,
+        };
+        ui.terminal().draw(|f| {
+            f.render_stateful_widget(EditorWidget::new(&self.rope), chunks[0], &mut state);
+            f.render_widget(
+                StatusBar {
+                    file_path: self.path.to_str().unwrap_or_default(),
+                    cursor: self.cursor.position(),
+                    lock_status: LockStatus::None,
+                    connection_status: ConnectionStatus::Online,
+                    dirty: self.dirty,
+                    mode: Mode::Local,
+                },
+                chunks[1],
+            );
+        })?;
+        Ok(())
+    }
+
+    /// Run a simple event loop until Ctrl+Q is pressed.
+    pub fn run(&mut self) -> Result<()> {
+        use crossterm::event::{poll, read};
+        use std::time::Duration;
+
+        let mut ui = TerminalUI::new()?;
+        loop {
+            self.draw(&mut ui)?;
+            if poll(Duration::from_millis(50))? {
+                if let Event::Key(key) = read()? {
+                    if key.code == KeyCode::Char('q')
+                        && key.modifiers.contains(KeyModifiers::CONTROL)
+                    {
+                        break;
+                    }
+                    self.handle_key(key);
+                }
+            }
+        }
+        ui.cleanup()?;
+        if self.dirty {
+            self.save()?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_open_modify_and_save() {
+        let mut file = NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut file, b"hi").unwrap();
+        let path = file.path().to_path_buf();
+        let mut app = App::open(&path).unwrap();
+        app.cursor.move_doc_end(&app.rope);
+        app.handle_key(KeyEvent::new(KeyCode::Char('!'), KeyModifiers::empty()));
+        app.save().unwrap();
+        let data = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(data, "hi!");
+    }
+
+    #[test]
+    fn test_draw_renders_without_error() {
+        let file = NamedTempFile::new().unwrap();
+        let mut app = App::open(file.path()).unwrap();
+        let backend = TestBackend::new(40, 5);
+        let mut ui = TerminalUI::with_backend(backend).unwrap();
+        assert!(app.draw(&mut ui).is_ok());
+    }
 }

--- a/ghostwriter/src/editor/mod.rs
+++ b/ghostwriter/src/editor/mod.rs
@@ -7,6 +7,7 @@ pub mod search;
 pub mod selection;
 pub mod undo;
 
+#[allow(dead_code)]
 pub fn hello_editor() {
     println!("Hello from editor module!");
 }

--- a/ghostwriter/src/main.rs
+++ b/ghostwriter/src/main.rs
@@ -54,11 +54,23 @@ fn main() {
             eprintln!("Error: {e}");
             std::process::exit(1);
         }
+    } else if let Some(path) = args.path {
+        match app::App::open(path) {
+            Ok(mut app) => {
+                if let Err(e) = app.run() {
+                    error!("{e}");
+                    eprintln!("Error: {e}");
+                    std::process::exit(1);
+                }
+            }
+            Err(e) => {
+                error!("{e}");
+                eprintln!("Error: {e}");
+                std::process::exit(1);
+            }
+        }
     } else {
-        println!("Parsed arguments: {args:?}");
-        // Placeholder module calls
-        app::hello_app();
-        editor::hello_editor();
+        println!("No operation specified. Use --help for options.");
     }
 }
 
@@ -132,8 +144,8 @@ mod tests {
 
     #[test]
     fn test_modules_callable() {
-        // Check if placeholder functions from modules are callable
-        app::hello_app();
+        // Basic sanity checks on module API accessibility
+        let _app = app::App::open(std::env::temp_dir().join("tmp.txt"));
         editor::hello_editor();
         let _ = files::file_manager::FileManager::is_binary(b"test");
         let msg = network::protocol::Message {


### PR DESCRIPTION
## Summary
- implement `App` with simple event loop
- hook CLI to run `App` for local file editing
- add unit tests for new app module
- minor cleanup for editor module

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685cf9247ba48332b1275c7f3a146aa2