### PR TITLE
Implement release artifact workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Build Release Artifacts
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          target: ${{ matrix.target }}
+
+      - name: Install Linux deps
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - name: Build release
+        working-directory: ./ghostwriter
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Archive binary
+        run: |
+          tar -czf ghostwriter-${{ matrix.target }}.tar.gz -C ghostwriter/target/${{ matrix.target }}/release ghostwriter
+
+      - name: Upload artifact
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ghostwriter-${{ matrix.target }}.tar.gz

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ cargo build --release --target <target-triple>
 
 Static linking flags are configured in `.cargo/config.toml` for Linux targets so the resulting binaries have no external dependencies.
 
+## GitHub Release Builds
+
+Publishing a release on GitHub triggers CI to compile static binaries for Linux (x86_64 and ARM64) and macOS ARM64. The resulting archives are uploaded to the release page automatically.
+
+
 ## Usage Examples
 
 Start a server hosting a workspace directory:


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build binaries for multiple targets when a release is created
- document the new release process in README

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685d485733c48332bf29cc688cfbd0f6