### PR TITLE
Fix GitHub release permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     strategy:
@@ -43,3 +46,5 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: ghostwriter-${{ matrix.target }}.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ghostwriter/tests/github.rs
+++ b/ghostwriter/tests/github.rs
@@ -1,0 +1,11 @@
+use std::fs;
+
+#[test]
+fn release_workflow_has_write_permission() {
+    let yaml =
+        fs::read_to_string("../.github/workflows/release.yml").expect("release workflow not found");
+    assert!(
+        yaml.contains("permissions:") && yaml.contains("contents: write"),
+        "release workflow must grant write permissions to contents"
+    );
+}


### PR DESCRIPTION
## Summary
- ensure GitHub workflow token can update releases
- add test verifying release workflow permissions

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685d72c537048332b24a6ce45ee8ee20