### PR TITLE
Fix Linux ARM64 build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y musl-tools gcc-aarch64-linux-gnu
+          sudo apt-get install -y musl-tools gcc-aarch64-linux-gnu crossbuild-essential-arm64
 
       - name: Build release
         working-directory: ./ghostwriter

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ cargo build --release --target <target-triple>
 ```
 
 Static linking flags are configured in `.cargo/config.toml` for Linux targets so the resulting binaries have no external dependencies.
+For Linux ARM64 builds make sure `crossbuild-essential-arm64` is installed so the
+correct cross-compiling linker and libraries are available.
 
 ## GitHub Release Builds
 

--- a/ghostwriter/.cargo/config.toml
+++ b/ghostwriter/.cargo/config.toml
@@ -9,6 +9,7 @@
 # rustflags = ["-C", "target-feature=+crt-static"]
 
 [target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
 rustflags = ["-C", "target-feature=+crt-static"]
 
 # For fully static Linux binaries (no dynamic libc dependency), MUSL targets are often preferred.


### PR DESCRIPTION
## Summary
- configure cross linker for ARM64
- install crossbuild tools in release workflow
- document required package for ARM64 builds

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo build --release --target aarch64-unknown-linux-gnu`


------
https://chatgpt.com/codex/tasks/task_e_685d7d1225748332b1f0d3dc58af9c78