### PR TITLE
feat: add rope buffer read/open with invalid UTF-8 tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +413,8 @@ name = "ghostwriter-core"
 version = "0.1.0"
 dependencies = [
  "futures-util",
+ "ropey",
+ "tempfile",
  "tokio",
  "tokio-tungstenite",
 ]
@@ -476,6 +494,12 @@ name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
@@ -809,10 +833,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ropey"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93411e420bcd1a75ddd1dc3caf18c23155eda2c090631a85af21ba19e97093b5"
+dependencies = [
+ "smallvec",
+ "str_indices",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "rustls"
@@ -975,6 +1022,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "str_indices"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +1048,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@
 
 # Phase 1 — Core Editor (Local In-Proc Loop)
 
-* [ ] **RopeBuffer (read/open)** — load file with UTF-8 + invalid-byte tracking (hex fallback flag).
+* [x] **RopeBuffer (read/open)** — load file with UTF-8 + invalid-byte tracking (hex fallback flag).
 * [ ] **RopeBuffer (edit ops)** — `insert/delete`, byte↔line/col, grapheme left/right.
 * [ ] **Undo/Redo stack** — linear history, coalescing adjacent inserts.
 * [ ] **Viewport composer** — slice by lines, minimal style spans, status line, cursor(s).

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -7,3 +7,7 @@ edition.workspace = true
 tokio = { version = "1.47.1", features = ["full"] }
 tokio-tungstenite = { version = "0.27.0", features = ["rustls-tls-native-roots"] }
 futures-util = "0.3.31"
+ropey = "1.6.1"
+
+[dev-dependencies]
+tempfile = "3.10.1"

--- a/crates/core/src/buffer.rs
+++ b/crates/core/src/buffer.rs
@@ -1,0 +1,61 @@
+use ropey::Rope;
+use std::{io, path::Path};
+
+/// Rope-based text buffer with invalid UTF-8 tracking.
+pub struct RopeBuffer {
+    rope: Rope,
+    has_invalid: bool,
+}
+
+impl RopeBuffer {
+    /// Open a file from disk into a `RopeBuffer`.
+    pub fn open<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        let bytes = std::fs::read(path)?;
+        let (text, has_invalid) = match String::from_utf8(bytes) {
+            Ok(s) => (s, false),
+            Err(e) => {
+                let bytes = e.into_bytes();
+                (String::from_utf8_lossy(&bytes).into_owned(), true)
+            }
+        };
+        Ok(Self {
+            rope: Rope::from_str(&text),
+            has_invalid,
+        })
+    }
+
+    /// Returns true if the loaded file contained invalid UTF-8 bytes.
+    pub fn has_invalid(&self) -> bool {
+        self.has_invalid
+    }
+
+    /// Returns the entire text as a [`String`].
+    pub fn text(&self) -> String {
+        self.rope.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn open_valid_utf8() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "hello").unwrap();
+        let buf = RopeBuffer::open(file.path()).unwrap();
+        assert_eq!(buf.text(), "hello\n");
+        assert!(!buf.has_invalid());
+    }
+
+    #[test]
+    fn open_invalid_utf8_sets_flag() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(&[0x66, 0x6f, 0x80, 0x6f]).unwrap();
+        let buf = RopeBuffer::open(file.path()).unwrap();
+        assert!(buf.has_invalid());
+        assert_eq!(buf.text(), "fo\u{FFFD}o");
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -3,8 +3,10 @@ pub fn add(a: i32, b: i32) -> i32 {
     a + b
 }
 
+pub mod buffer;
 pub mod transport;
 
+pub use buffer::RopeBuffer;
 pub use transport::Transport;
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- implement `RopeBuffer` for loading files with UTF-8 and invalid byte tracking
- expose `RopeBuffer` in core crate and mark TODO item complete

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo tarpaulin` *(fails: no such command: `tarpaulin`)*

------
https://chatgpt.com/codex/tasks/task_e_6899dda26258833290917a5eb065f523