### PR TITLE
feat: compose viewport frames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,7 @@ name = "ghostwriter-core"
 version = "0.1.0"
 dependencies = [
  "futures-util",
+ "ghostwriter-proto",
  "ropey",
  "tempfile",
  "tokio",

--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,7 @@
 * [x] **RopeBuffer (read/open)** — load file with UTF-8 + invalid-byte tracking (hex fallback flag).
 * [x] **RopeBuffer (edit ops)** — `insert/delete`, byte↔line/col, grapheme left/right.
 * [x] **Undo/Redo stack** — linear history, coalescing adjacent inserts.
-* [ ] **Viewport composer** — slice by lines, minimal style spans, status line, cursor(s).
+* [x] **Viewport composer** — slice by lines, minimal style spans, status line, cursor(s).
 * [ ] **Atomic save** — temp+rename+fsync(dir); preserve EOL; configurable debounce (100ms).
 * [ ] **WAL writer/reader** — append before apply; CRC; replay on start; compaction threshold.
 * [ ] **Minimal session actor** — holds buffer, doc\_v, selection, debounce; emits Frames.

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,6 +9,7 @@ tokio-tungstenite = { version = "0.27.0", features = ["rustls-tls-native-roots"]
 futures-util = "0.3.31"
 ropey = "1.6.1"
 unicode-segmentation = "1.11.0"
+ghostwriter-proto = { path = "../proto" }
 
 [dev-dependencies]
 tempfile = "3.10.1"

--- a/crates/core/src/buffer.rs
+++ b/crates/core/src/buffer.rs
@@ -63,6 +63,24 @@ impl RopeBuffer {
         self.rope.slice(start..end).to_string()
     }
 
+    /// Return up to `max_lines` lines starting from `first_line`.
+    /// Lines are returned without their terminating newline characters.
+    pub fn slice_lines(&self, first_line: usize, max_lines: usize) -> Vec<String> {
+        let total = self.rope.len_lines();
+        let mut out = Vec::new();
+        for i in first_line..(first_line + max_lines).min(total) {
+            let mut line = self.rope.line(i).to_string();
+            if line.ends_with('\n') {
+                line.pop();
+                if line.ends_with('\r') {
+                    line.pop();
+                }
+            }
+            out.push(line);
+        }
+        out
+    }
+
     /// Convert a byte index to a (line, column) pair.
     /// Line and column are both zero-based, and column counts bytes from
     /// the start of the line.
@@ -160,5 +178,14 @@ mod tests {
         assert_eq!(buf.grapheme_left(7), Some(3));
         assert_eq!(buf.grapheme_left(3), Some(0));
         assert_eq!(buf.grapheme_left(0), None);
+    }
+
+    #[test]
+    fn slice_lines() {
+        let buf = RopeBuffer::from_text("a\nb\nc\nd");
+        assert_eq!(
+            buf.slice_lines(1, 2),
+            vec!["b".to_string(), "c".to_string()]
+        );
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -6,10 +6,12 @@ pub fn add(a: i32, b: i32) -> i32 {
 pub mod buffer;
 pub mod transport;
 pub mod undo;
+pub mod viewport;
 
 pub use buffer::RopeBuffer;
 pub use transport::Transport;
 pub use undo::UndoStack;
+pub use viewport::compose;
 
 #[cfg(test)]
 mod tests {

--- a/crates/core/src/viewport.rs
+++ b/crates/core/src/viewport.rs
@@ -1,0 +1,163 @@
+// Viewport composer: converts buffer and selections into proto::Frame.
+
+use std::ops::Range;
+
+use crate::RopeBuffer;
+use ghostwriter_proto::{Cursor, Frame, StyleSpan};
+
+/// Compose a frame for the given viewport parameters.
+pub fn compose(
+    buf: &RopeBuffer,
+    first_line: usize,
+    rows: usize,
+    cols: usize,
+    hscroll: usize,
+    cursors: &[(usize, usize)],
+    selection: Option<Range<usize>>,
+) -> Frame {
+    // Extract and horizontally slice lines.
+    let raw_lines = buf.slice_lines(first_line, rows);
+    let lines: Vec<String> = raw_lines
+        .into_iter()
+        .map(|line| {
+            if hscroll < line.len() {
+                let end = (hscroll + cols).min(line.len());
+                line[hscroll..end].to_string()
+            } else {
+                String::new()
+            }
+        })
+        .collect();
+
+    let mut spans = Vec::new();
+
+    for (row, line) in lines.iter().enumerate() {
+        let trimmed = line.trim_end_matches(|c| c == ' ' || c == '\t');
+        if trimmed.len() < line.len() {
+            spans.push(StyleSpan {
+                row: row as u16,
+                start_col: trimmed.len() as u16,
+                end_col: line.len() as u16,
+                class: "ws".into(),
+            });
+        }
+
+        let mut col = 0usize;
+        for ch in line.chars() {
+            if ch == '\u{FFFD}' {
+                spans.push(StyleSpan {
+                    row: row as u16,
+                    start_col: col as u16,
+                    end_col: (col + 1) as u16,
+                    class: "err".into(),
+                });
+            }
+            col += 1;
+        }
+    }
+
+    if let Some(sel) = selection {
+        let (start_line, start_col) = buf.byte_to_line_col(sel.start);
+        let (end_line, end_col) = buf.byte_to_line_col(sel.end);
+        for line in start_line..=end_line {
+            if line < first_line || line >= first_line + rows {
+                continue;
+            }
+            let row = (line - first_line) as u16;
+            let start = if line == start_line { start_col } else { 0 };
+            let end = if line == end_line {
+                end_col
+            } else {
+                buf.slice_lines(line, 1)
+                    .first()
+                    .map(|s| s.len())
+                    .unwrap_or(0)
+            };
+            if end > start {
+                let adj_start = start.saturating_sub(hscroll);
+                let adj_end = end.saturating_sub(hscroll);
+                if adj_end > 0 && adj_start < cols {
+                    spans.push(StyleSpan {
+                        row,
+                        start_col: adj_start.min(cols) as u16,
+                        end_col: adj_end.min(cols) as u16,
+                        class: "sel".into(),
+                    });
+                }
+            }
+        }
+    }
+
+    let mut cursor_out = Vec::new();
+    for &(line, col) in cursors {
+        if line < first_line || line >= first_line + rows {
+            continue;
+        }
+        if col < hscroll || col >= hscroll + cols {
+            continue;
+        }
+        cursor_out.push(Cursor {
+            row: (line - first_line) as u16,
+            col: (col - hscroll) as u16,
+        });
+    }
+
+    let status = if let Some(&(line, col)) = cursors.first() {
+        format!("Ln {}, Col {}", line + 1, col + 1)
+    } else {
+        String::new()
+    };
+
+    Frame {
+        first_line: first_line as u64,
+        lines,
+        spans,
+        cursors: cursor_out,
+        status,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RopeBuffer;
+    use ghostwriter_proto::{Cursor, StyleSpan};
+
+    #[test]
+    fn compose_basic() {
+        let buf = RopeBuffer::from_text("hello  \nworld\n");
+        let cursor = (0usize, 1usize);
+        let selection = Some(1..4);
+        let frame = compose(&buf, 0, 2, 80, 0, &[cursor], selection);
+        assert_eq!(
+            frame.lines,
+            vec!["hello  ".to_string(), "world".to_string()]
+        );
+        assert_eq!(frame.cursors, vec![Cursor { row: 0, col: 1 }]);
+        assert_eq!(frame.status, "Ln 1, Col 2");
+        assert!(frame.spans.contains(&StyleSpan {
+            row: 0,
+            start_col: 1,
+            end_col: 4,
+            class: "sel".into()
+        }));
+        assert!(frame.spans.contains(&StyleSpan {
+            row: 0,
+            start_col: 5,
+            end_col: 7,
+            class: "ws".into()
+        }));
+    }
+
+    #[test]
+    fn compose_error_span() {
+        let buf = RopeBuffer::from_text("bad\u{FFFD}line\n");
+        let frame = compose(&buf, 0, 1, 80, 0, &[], None);
+        assert!(frame.spans.contains(&StyleSpan {
+            row: 0,
+            start_col: 3,
+            end_col: 4,
+            class: "err".into()
+        }));
+    }
+}

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -84,6 +84,30 @@ pub struct Copy {
     pub text: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Cursor {
+    pub row: u16,
+    pub col: u16,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct StyleSpan {
+    pub row: u16,
+    pub start_col: u16,
+    pub end_col: u16,
+    #[serde(rename = "class")]
+    pub class: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Frame {
+    pub first_line: u64,
+    pub lines: Vec<String>,
+    pub spans: Vec<StyleSpan>,
+    pub cursors: Vec<Cursor>,
+    pub status: String,
+}
+
 pub fn encode<T: Serialize>(envelope: &Envelope<T>) -> Result<Vec<u8>, rmp_serde::encode::Error> {
     rmp_serde::to_vec(envelope)
 }
@@ -125,5 +149,21 @@ mod tests {
         let decoded: Envelope<Copy> = decode(&encoded).expect("decode");
         assert_eq!(decoded.ty, MessageType::Copy);
         assert_eq!(decoded.data, copy);
+    }
+
+    #[test]
+    fn frame_roundtrip() {
+        let frame = Frame {
+            first_line: 0,
+            lines: vec!["hi".into()],
+            spans: vec![],
+            cursors: vec![Cursor { row: 0, col: 0 }],
+            status: "ok".into(),
+        };
+        let env = Envelope::new(MessageType::Frame, frame.clone());
+        let encoded = encode(&env).expect("encode");
+        let decoded: Envelope<Frame> = decode(&encoded).expect("decode");
+        assert_eq!(decoded.ty, MessageType::Frame);
+        assert_eq!(decoded.data, frame);
     }
 }


### PR DESCRIPTION
## Summary
- add protocol structs for Frame, Cursor, and StyleSpan
- implement RopeBuffer line slicing and viewport composer with minimal styling
- mark viewport composer task complete in TODO

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --workspace`
- `cargo tarpaulin --workspace`


------
https://chatgpt.com/codex/tasks/task_e_6899fd8170108332ace273143d2eab1a