### PR TITLE
feat(core): implement viewport composer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,7 @@ name = "ghostwriter-core"
 version = "0.1.0"
 dependencies = [
  "futures-util",
+ "ghostwriter-proto",
  "ropey",
  "tempfile",
  "tokio",

--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,7 @@
 * [x] **RopeBuffer (read/open)** — load file with UTF-8 + invalid-byte tracking (hex fallback flag).
 * [x] **RopeBuffer (edit ops)** — `insert/delete`, byte↔line/col, grapheme left/right.
 * [x] **Undo/Redo stack** — linear history, coalescing adjacent inserts.
-* [ ] **Viewport composer** — slice by lines, minimal style spans, status line, cursor(s).
+* [x] **Viewport composer** — slice by lines, minimal style spans, status line, cursor(s).
 * [ ] **Atomic save** — temp+rename+fsync(dir); preserve EOL; configurable debounce (100ms).
 * [ ] **WAL writer/reader** — append before apply; CRC; replay on start; compaction threshold.
 * [ ] **Minimal session actor** — holds buffer, doc\_v, selection, debounce; emits Frames.

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,6 +9,7 @@ tokio-tungstenite = { version = "0.27.0", features = ["rustls-tls-native-roots"]
 futures-util = "0.3.31"
 ropey = "1.6.1"
 unicode-segmentation = "1.11.0"
+ghostwriter-proto = { path = "../proto" }
 
 [dev-dependencies]
 tempfile = "3.10.1"

--- a/crates/core/src/buffer.rs
+++ b/crates/core/src/buffer.rs
@@ -43,6 +43,31 @@ impl RopeBuffer {
         self.rope.to_string()
     }
 
+    /// Return up to `max_lines` lines starting from `first_line`.
+    /// Lines are returned without trailing newlines.
+    pub fn slice_lines(&self, first_line: usize, max_lines: usize) -> Vec<String> {
+        let total = self.rope.len_lines();
+        let mut out = Vec::new();
+        for i in first_line..std::cmp::min(first_line + max_lines, total) {
+            let mut line = self.rope.line(i).to_string();
+            if line.ends_with('\n') {
+                line.pop();
+            }
+            out.push(line);
+        }
+        out
+    }
+
+    /// Return the byte index at the start of `line`.
+    pub fn line_to_byte(&self, line: usize) -> usize {
+        self.rope.line_to_byte(line)
+    }
+
+    /// Total number of lines in the buffer.
+    pub fn len_lines(&self) -> usize {
+        self.rope.len_lines()
+    }
+
     /// Insert `text` at the given byte index.
     pub fn insert(&mut self, byte_idx: usize, text: &str) {
         let char_idx = self.rope.byte_to_char(byte_idx);

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -6,10 +6,12 @@ pub fn add(a: i32, b: i32) -> i32 {
 pub mod buffer;
 pub mod transport;
 pub mod undo;
+pub mod viewport;
 
 pub use buffer::RopeBuffer;
 pub use transport::Transport;
 pub use undo::UndoStack;
+pub use viewport::{ViewportParams, compose as compose_viewport};
 
 #[cfg(test)]
 mod tests {

--- a/crates/core/src/viewport.rs
+++ b/crates/core/src/viewport.rs
@@ -1,0 +1,163 @@
+use std::ops::Range;
+
+use ghostwriter_proto::{Cursor, Frame, Line, StyleSpan};
+
+use crate::buffer::RopeBuffer;
+
+/// Parameters controlling viewport composition.
+pub struct ViewportParams<'a> {
+    /// Selections to highlight, expressed as byte ranges.
+    pub selections: &'a [Range<usize>],
+    /// Cursor byte offsets to report in the frame.
+    pub cursors: &'a [usize],
+    /// Document version included with the frame.
+    pub doc_v: u64,
+    /// Left status line text.
+    pub status_left: &'a str,
+    /// Right status line text.
+    pub status_right: &'a str,
+}
+
+pub fn compose(
+    buf: &RopeBuffer,
+    first_line: usize,
+    cols: u16,
+    rows: u16,
+    hscroll: u16,
+    params: ViewportParams<'_>,
+) -> Frame {
+    let mut lines_out = Vec::new();
+    let raw_lines = buf.slice_lines(first_line, rows as usize);
+    for (idx, mut line) in raw_lines.into_iter().enumerate() {
+        let line_idx = first_line + idx;
+        let line_start = buf.line_to_byte(line_idx);
+        let line_end = line_start + line.len();
+        let mut spans: Vec<StyleSpan> = Vec::new();
+
+        // Selection spans
+        for sel in params.selections {
+            let start = sel.start.max(line_start);
+            let end = sel.end.min(line_end);
+            if start < end {
+                let mut sc = (start - line_start) as i64;
+                let mut ec = (end - line_start) as i64;
+                let hs = hscroll as i64;
+                if ec > hs && sc < hs + cols as i64 {
+                    sc = sc.max(hs) - hs;
+                    ec = ec.min(hs + cols as i64) - hs;
+                    spans.push(StyleSpan {
+                        start_col: sc as u16,
+                        end_col: ec as u16,
+                        class_name: "sel".into(),
+                    });
+                }
+            }
+        }
+
+        // Trailing whitespace span
+        let trimmed_len = line.trim_end_matches([' ', '\t']).len();
+        if trimmed_len < line.len() {
+            let mut start = trimmed_len as i64;
+            let mut end = line.len() as i64;
+            let hs = hscroll as i64;
+            if end > hs && start < hs + cols as i64 {
+                start = start.max(hs) - hs;
+                end = end.min(hs + cols as i64) - hs;
+                spans.push(StyleSpan {
+                    start_col: start as u16,
+                    end_col: end as u16,
+                    class_name: "ws".into(),
+                });
+            }
+        }
+
+        // Apply horizontal scroll to text
+        let start = hscroll as usize;
+        if start < line.len() {
+            let end = std::cmp::min(line.len(), start + cols as usize);
+            line = line[start..end].to_string();
+        } else {
+            line.clear();
+        }
+
+        lines_out.push(Line { text: line, spans });
+    }
+
+    let mut cursor_out = Vec::new();
+    for &c in params.cursors {
+        let (line, col) = buf.byte_to_line_col(c);
+        cursor_out.push(Cursor {
+            line: line as u64,
+            col: col as u16,
+        });
+    }
+
+    Frame {
+        id: "editor".into(),
+        kind: "editor".into(),
+        doc_v: params.doc_v,
+        first_line: first_line as u64,
+        cols,
+        rows,
+        lines: lines_out,
+        cursors: cursor_out,
+        status_left: params.status_left.into(),
+        status_right: params.status_right.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn composes_selection_and_whitespace() {
+        let buf = RopeBuffer::from_text("hello \nworld\t\n");
+        let selections: Vec<Range<usize>> = std::iter::once(3..9).collect();
+        let cursors = vec![8];
+        let params = ViewportParams {
+            selections: &selections,
+            cursors: &cursors,
+            doc_v: 1,
+            status_left: "L",
+            status_right: "R",
+        };
+        let frame = compose(&buf, 0, 10, 2, 0, params);
+        assert_eq!(frame.lines.len(), 2);
+        assert_eq!(frame.lines[0].text, "hello ");
+        assert_eq!(frame.lines[1].text, "world\t");
+        assert_eq!(
+            frame.lines[0].spans,
+            vec![
+                StyleSpan {
+                    start_col: 3,
+                    end_col: 6,
+                    class_name: "sel".into(),
+                },
+                StyleSpan {
+                    start_col: 5,
+                    end_col: 6,
+                    class_name: "ws".into(),
+                },
+            ]
+        );
+        assert_eq!(
+            frame.lines[1].spans,
+            vec![
+                StyleSpan {
+                    start_col: 0,
+                    end_col: 2,
+                    class_name: "sel".into(),
+                },
+                StyleSpan {
+                    start_col: 5,
+                    end_col: 6,
+                    class_name: "ws".into(),
+                },
+            ]
+        );
+        assert_eq!(frame.cursors, vec![Cursor { line: 1, col: 1 }]);
+        assert_eq!(frame.status_left, "L");
+        assert_eq!(frame.status_right, "R");
+    }
+}


### PR DESCRIPTION
## Summary
- add Frame and styling types to proto crate
- implement viewport composer with selection and whitespace spans
- consolidate viewport parameters into a struct to satisfy clippy
- mark viewport composer task complete in TODO

## Testing
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo tarpaulin --workspace --timeout 120`


------
https://chatgpt.com/codex/tasks/task_e_689a0abe0a108332a6e8ea543e470086