### PR TITLE
feat: map keys to editor commands

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,7 @@
 * [x] **WAL writer/reader** — append before apply; CRC; replay on start; compaction threshold.
 * [x] **Minimal session actor** — holds buffer, doc\_v, selection, debounce; emits Frames.
 * [x] **TUI bootstrap (ratatui)** — raw mode, draw frame, status, cursor placement.
-* [ ] **Key→command mapping** — translate keystrokes to `Insert/Delete/Move/Select/...`.
+* [x] **Key→command mapping** — translate keystrokes to `Insert/Delete/Move/Select/...`.
 * [ ] **Local loop glue** — in-proc channels client↔session (no WS yet); open/save workflow.
 * [ ] **Hex viewer (RO)** — 16B/row, ASCII gutter; auto-trigger on invalid UTF-8.
 * [ ] **Acceptance pack #1** — tests for edit/undo/save/WAL; crash-replay works.

--- a/crates/client/src/keymap.rs
+++ b/crates/client/src/keymap.rs
@@ -1,0 +1,103 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+/// Direction for cursor movement or selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Direction {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+
+/// High-level editor command derived from a key event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Command {
+    /// Insert the given text at the cursor position.
+    Insert(String),
+    /// Delete the character before the cursor.
+    DeletePrev,
+    /// Delete the character at the cursor.
+    DeleteNext,
+    /// Move the cursor in the given direction without modifying the selection.
+    Move(Direction),
+    /// Extend the selection in the given direction.
+    Select(Direction),
+}
+
+/// Translate a crossterm [`KeyEvent`] into an editor [`Command`].
+///
+/// Returns `None` for keys that have no associated command.
+pub fn map_key_event(ev: KeyEvent) -> Option<Command> {
+    match ev.code {
+        KeyCode::Char(c) => {
+            if ev
+                .modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+            {
+                None
+            } else {
+                Some(Command::Insert(c.to_string()))
+            }
+        }
+        KeyCode::Enter => Some(Command::Insert("\n".into())),
+        KeyCode::Tab => Some(Command::Insert("\t".into())),
+        KeyCode::Backspace => Some(Command::DeletePrev),
+        KeyCode::Delete => Some(Command::DeleteNext),
+        KeyCode::Left => Some(if ev.modifiers.contains(KeyModifiers::SHIFT) {
+            Command::Select(Direction::Left)
+        } else {
+            Command::Move(Direction::Left)
+        }),
+        KeyCode::Right => Some(if ev.modifiers.contains(KeyModifiers::SHIFT) {
+            Command::Select(Direction::Right)
+        } else {
+            Command::Move(Direction::Right)
+        }),
+        KeyCode::Up => Some(if ev.modifiers.contains(KeyModifiers::SHIFT) {
+            Command::Select(Direction::Up)
+        } else {
+            Command::Move(Direction::Up)
+        }),
+        KeyCode::Down => Some(if ev.modifiers.contains(KeyModifiers::SHIFT) {
+            Command::Select(Direction::Down)
+        } else {
+            Command::Move(Direction::Down)
+        }),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_char_to_insert() {
+        let ev = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
+        assert_eq!(map_key_event(ev), Some(Command::Insert("a".into())));
+    }
+
+    #[test]
+    fn maps_enter_to_newline() {
+        let ev = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+        assert_eq!(map_key_event(ev), Some(Command::Insert("\n".into())));
+    }
+
+    #[test]
+    fn maps_backspace_to_delete_prev() {
+        let ev = KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE);
+        assert_eq!(map_key_event(ev), Some(Command::DeletePrev));
+    }
+
+    #[test]
+    fn maps_left_to_move_left() {
+        let ev = KeyEvent::new(KeyCode::Left, KeyModifiers::NONE);
+        assert_eq!(map_key_event(ev), Some(Command::Move(Direction::Left)));
+    }
+
+    #[test]
+    fn maps_shift_left_to_select_left() {
+        let ev = KeyEvent::new(KeyCode::Left, KeyModifiers::SHIFT);
+        assert_eq!(map_key_event(ev), Some(Command::Select(Direction::Left)));
+    }
+}

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod keymap;
 pub mod tui;
 
 /// Client entry point.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,7 +47,7 @@ pub async fn run() -> Result<()> {
 async fn run_with_args(args: Args) -> Result<&'static str> {
     init_logging();
     let output = dispatch(args.mode()?);
-    println!("{}", output);
+    println!("{output}");
     Ok(output)
 }
 


### PR DESCRIPTION
## Summary
- add keymap module translating crossterm key events into editing commands
- expose keymap from client crate and mark TODO item complete
- inline format args in CLI

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features --locked`


------
https://chatgpt.com/codex/tasks/task_e_689afcccaef483329e8630e12dbf50dd