### PR TITLE
feat: add local in-proc session loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "assert_cmd"
@@ -195,9 +195,9 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "clap"
-version = "4.5.43"
+version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
+checksum = "1c1f056bae57e3e54c3375c41ff79619ddd13460a17d7438712bd0d83fda4ff8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.43"
+version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -549,7 +549,10 @@ dependencies = [
  "anyhow",
  "crossterm 0.27.0",
  "ghostwriter-proto",
+ "ghostwriter-server",
  "ratatui",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -581,6 +584,7 @@ version = "0.1.0"
 dependencies = [
  "ghostwriter-core",
  "ghostwriter-proto",
+ "tempfile",
  "tokio",
 ]
 
@@ -918,9 +922,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beef09f85ae72cea1ef96ba6870c51e6382ebfa4f0e85b643459331f3daa5be0"
+checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
 dependencies = [
  "unicode-ident",
 ]
@@ -1423,18 +1427,18 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/TODO.md
+++ b/TODO.md
@@ -19,7 +19,7 @@
 * [x] **Minimal session actor** — holds buffer, doc\_v, selection, debounce; emits Frames.
 * [x] **TUI bootstrap (ratatui)** — raw mode, draw frame, status, cursor placement.
 * [x] **Key→command mapping** — translate keystrokes to `Insert/Delete/Move/Select/...`.
-* [ ] **Local loop glue** — in-proc channels client↔session (no WS yet); open/save workflow.
+* [x] **Local loop glue** — in-proc channels client↔session (no WS yet); open/save workflow.
 * [ ] **Hex viewer (RO)** — 16B/row, ASCII gutter; auto-trigger on invalid UTF-8.
 * [ ] **Acceptance pack #1** — tests for edit/undo/save/WAL; crash-replay works.
 

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -8,3 +8,8 @@ anyhow = "1.0.98"
 crossterm = "0.27.0"
 ratatui = { version = "0.28.0", default-features = false, features = ["crossterm"] }
 ghostwriter-proto = { path = "../proto" }
+ghostwriter-server = { path = "../server" }
+
+[dev-dependencies]
+tempfile = "3.10.1"
+tokio = { version = "1.47.1", features = ["full"] }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod keymap;
+pub mod local;
 pub mod tui;
 
 /// Client entry point.

--- a/crates/client/src/local.rs
+++ b/crates/client/src/local.rs
@@ -1,0 +1,43 @@
+use std::io;
+use std::path::PathBuf;
+
+use ghostwriter_proto::Frame;
+use ghostwriter_server::session::{self, SessionCmd, SessionHandle};
+
+/// Local in-process client connected to a session via channels.
+pub struct LocalClient {
+    handle: SessionHandle,
+}
+
+impl LocalClient {
+    /// Open a file at `path` and spawn a session with the given viewport size.
+    pub fn open(path: PathBuf, cols: u16, rows: u16) -> io::Result<Self> {
+        let handle = session::open(path, cols, rows)?;
+        Ok(Self { handle })
+    }
+
+    /// Send an insert command to the session.
+    pub async fn insert(&mut self, text: &str) {
+        let _ = self
+            .handle
+            .cmd
+            .send(SessionCmd::Insert { text: text.into() })
+            .await;
+    }
+
+    /// Request the current frame and wait for it.
+    pub async fn request_frame(&mut self) -> Frame {
+        let _ = self.handle.cmd.send(SessionCmd::RequestFrame).await;
+        self.next_frame().await
+    }
+
+    /// Receive the next frame emitted by the session.
+    pub async fn next_frame(&mut self) -> Frame {
+        self.handle.frames.recv().await.unwrap()
+    }
+
+    /// Trigger an immediate save of the buffer to disk.
+    pub async fn save(&mut self) {
+        let _ = self.handle.cmd.send(SessionCmd::Save).await;
+    }
+}

--- a/crates/client/tests/local_loop.rs
+++ b/crates/client/tests/local_loop.rs
@@ -1,0 +1,30 @@
+use ghostwriter_client::local::LocalClient;
+use std::io::{Read, Write};
+use tempfile::NamedTempFile;
+
+#[tokio::test]
+async fn open_insert_save() {
+    let mut file = NamedTempFile::new().unwrap();
+    write!(file, "hi").unwrap();
+    let path = file.path().to_path_buf();
+
+    let mut client = LocalClient::open(path.clone(), 80, 24).unwrap();
+
+    // initial frame
+    let frame = client.request_frame().await;
+    assert_eq!(frame.lines[0].text, "hi");
+
+    client.insert(" there").await;
+    let frame = client.next_frame().await;
+    assert_eq!(frame.lines[0].text, " therehi");
+
+    client.save().await;
+    let _ = client.request_frame().await; // ensure save processed
+
+    let mut contents = String::new();
+    std::fs::File::open(&path)
+        .unwrap()
+        .read_to_string(&mut contents)
+        .unwrap();
+    assert_eq!(contents, " therehi");
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -7,3 +7,6 @@ edition.workspace = true
 ghostwriter-core = { path = "../core" }
 ghostwriter-proto = { path = "../proto" }
 tokio = { version = "1.47.1", features = ["full"] }
+
+[dev-dependencies]
+tempfile = "3.10.1"


### PR DESCRIPTION
## Summary
- connect client and session via in-process channels
- support opening files and saving edits to disk
- add integration test exercising local open/insert/save

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features --locked`


------
https://chatgpt.com/codex/tasks/task_e_689b028bdfcc83329f955a9d0c38f4df