### PR TITLE
feat(server): add single-session WS acceptor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,10 +584,12 @@ dependencies = [
 name = "ghostwriter-server"
 version = "0.1.0"
 dependencies = [
+ "futures-util",
  "ghostwriter-core",
  "ghostwriter-proto",
  "tempfile",
  "tokio",
+ "tokio-tungstenite",
 ]
 
 [[package]]

--- a/TODO.md
+++ b/TODO.md
@@ -27,7 +27,7 @@
 
 # Phase 2 — Real Server & Single-User Control
 
-* [ ] **WS acceptor (TCP/UDS)** — serve one active session; reject others with `Busy`.
+* [x] **WS acceptor (TCP/UDS)** — serve one active session; reject others with `Busy`.
 * [ ] **Client WS connector** — `Hello` handshake, `RequestFrame` on connect/resize.
 * [ ] **Auth (optional)** — Argon2id storage file, login flow, shared-secret env/CLI.
 * [ ] **Rate limiting** — 3/min per peer; error `RateLimit`; backoff hints.

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -118,6 +118,24 @@ pub struct Frame {
     pub status_right: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum ErrorCode {
+    Unauthorized,
+    Invalid,
+    Unsupported,
+    Busy,
+    Io,
+    Sandbox,
+    Conflict,
+    RateLimit,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ErrorMsg {
+    pub code: ErrorCode,
+    pub msg: String,
+}
+
 pub fn encode<T: Serialize>(envelope: &Envelope<T>) -> Result<Vec<u8>, rmp_serde::encode::Error> {
     rmp_serde::to_vec(envelope)
 }
@@ -187,5 +205,18 @@ mod tests {
         let decoded: Envelope<Frame> = decode(&encoded).expect("decode");
         assert_eq!(decoded.ty, MessageType::Frame);
         assert_eq!(decoded.data, frame);
+    }
+
+    #[test]
+    fn error_roundtrip() {
+        let err = ErrorMsg {
+            code: ErrorCode::Busy,
+            msg: "busy".into(),
+        };
+        let env = Envelope::new(MessageType::Error, err.clone());
+        let encoded = encode(&env).expect("encode");
+        let decoded: Envelope<ErrorMsg> = decode(&encoded).expect("decode");
+        assert_eq!(decoded.ty, MessageType::Error);
+        assert_eq!(decoded.data, err);
     }
 }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -7,6 +7,8 @@ edition.workspace = true
 ghostwriter-core = { path = "../core" }
 ghostwriter-proto = { path = "../proto" }
 tokio = { version = "1.47.1", features = ["full"] }
+tokio-tungstenite = { version = "0.27.0", features = ["rustls-tls-native-roots"] }
+futures-util = "0.3.31"
 
 [dev-dependencies]
 tempfile = "3.10.1"

--- a/crates/server/src/acceptor.rs
+++ b/crates/server/src/acceptor.rs
@@ -1,0 +1,69 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
+use futures_util::{SinkExt, StreamExt};
+use ghostwriter_proto::{Envelope, ErrorCode, ErrorMsg, MessageType, encode};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::{TcpListener, UnixListener};
+use tokio_tungstenite::{WebSocketStream, accept_async, tungstenite::Message};
+
+async fn handle_busy<S>(mut ws: WebSocketStream<S>)
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let env = Envelope::new(
+        MessageType::Error,
+        ErrorMsg {
+            code: ErrorCode::Busy,
+            msg: "busy".into(),
+        },
+    );
+    if let Ok(data) = encode(&env) {
+        let _ = ws.send(Message::Binary(data.into())).await;
+    }
+    let _ = ws.close(None).await;
+}
+
+async fn handle_connection<S>(mut ws: WebSocketStream<S>, active: Arc<AtomicBool>)
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    while let Some(msg) = ws.next().await {
+        if msg.is_err() {
+            break;
+        }
+    }
+    active.store(false, Ordering::SeqCst);
+}
+
+pub async fn run_tcp(listener: TcpListener) -> tokio::io::Result<()> {
+    let active = Arc::new(AtomicBool::new(false));
+    loop {
+        let (stream, _) = listener.accept().await?;
+        let ws = accept_async(stream).await.map_err(std::io::Error::other)?;
+        if active.load(Ordering::SeqCst) {
+            handle_busy(ws).await;
+        } else {
+            active.store(true, Ordering::SeqCst);
+            let active_clone = Arc::clone(&active);
+            tokio::spawn(async move { handle_connection(ws, active_clone).await });
+        }
+    }
+}
+
+pub async fn run_uds(listener: UnixListener) -> tokio::io::Result<()> {
+    let active = Arc::new(AtomicBool::new(false));
+    loop {
+        let (stream, _) = listener.accept().await?;
+        let ws = accept_async(stream).await.map_err(std::io::Error::other)?;
+        if active.load(Ordering::SeqCst) {
+            handle_busy(ws).await;
+        } else {
+            active.store(true, Ordering::SeqCst);
+            let active_clone = Arc::clone(&active);
+            tokio::spawn(async move { handle_connection(ws, active_clone).await });
+        }
+    }
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod acceptor;
 pub mod session;
 
 /// Server entry point.

--- a/crates/server/tests/ws_acceptor.rs
+++ b/crates/server/tests/ws_acceptor.rs
@@ -1,0 +1,43 @@
+use futures_util::StreamExt;
+use ghostwriter_proto::{Envelope, ErrorCode, ErrorMsg, MessageType, decode};
+use ghostwriter_server::acceptor;
+use tokio::net::TcpListener;
+use tokio_tungstenite::tungstenite::Message;
+
+#[tokio::test]
+async fn rejects_second_client_with_busy() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        acceptor::run_tcp(listener).await.unwrap();
+    });
+
+    let (mut ws1, _) = tokio_tungstenite::connect_async(format!("ws://{addr}"))
+        .await
+        .unwrap();
+
+    let (mut ws2, _) = tokio_tungstenite::connect_async(format!("ws://{addr}"))
+        .await
+        .unwrap();
+
+    match ws2.next().await.unwrap().unwrap() {
+        Message::Binary(data) => {
+            let env: Envelope<ErrorMsg> = decode(&data).unwrap();
+            assert_eq!(env.ty, MessageType::Error);
+            assert_eq!(env.data.code, ErrorCode::Busy);
+        }
+        other => panic!("unexpected message: {other:?}"),
+    }
+    match ws2.next().await {
+        Some(Ok(Message::Close(_))) | None => {}
+        other => panic!("unexpected message: {other:?}"),
+    }
+
+    ws1.close(None).await.unwrap();
+    let (mut ws3, _) = tokio_tungstenite::connect_async(format!("ws://{addr}"))
+        .await
+        .unwrap();
+    ws3.close(None).await.unwrap();
+
+    server.abort();
+}


### PR DESCRIPTION
## Summary
- implement WebSocket acceptor for TCP and UDS allowing only one active session
- add Busy error support in protocol and test roundtrip
- verify second client receives Busy and subsequent connections succeed

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features --locked`


------
https://chatgpt.com/codex/tasks/task_e_689b21f6615c833296cd552a69e7e74f