### PR TITLE
feat: add auth handshake with Argon2 verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,10 +138,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64ct"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "block-buffer"
@@ -393,6 +420,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -607,9 +635,11 @@ dependencies = [
 name = "ghostwriter-server"
 version = "0.1.0"
 dependencies = [
+ "argon2",
  "futures-util",
  "ghostwriter-core",
  "ghostwriter-proto",
+ "rand_core 0.6.4",
  "tempfile",
  "tokio",
  "tokio-tungstenite",
@@ -1004,6 +1034,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,7 +1335,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1588,7 +1629,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition.workspace = true
 
 [dependencies]
 anyhow = "1.0.98"
-clap = { version = "4.5.43", features = ["derive"] }
+clap = { version = "4.5.43", features = ["derive", "env"] }
 tokio = { version = "1.47.1", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["fmt", "env-filter"] }

--- a/TODO.md
+++ b/TODO.md
@@ -29,7 +29,7 @@
 
 * [x] **WS acceptor (TCP/UDS)** — serve one active session; reject others with `Busy`.
 * [x] **Client WS connector** — `Hello` handshake, `RequestFrame` on connect/resize.
-* [ ] **Auth (optional)** — Argon2id storage file, login flow, shared-secret env/CLI.
+* [x] **Auth (optional)** — Argon2id storage file, login flow, shared-secret env/CLI.
 * [ ] **Rate limiting** — 3/min per peer; error `RateLimit`; backoff hints.
 * [ ] **Session lifecycle** — clean shutdown, lock release, save on exit; server banner/status.
 * [ ] **Logging & audit** — JSON logs + audit of open/save/rename/delete/auth (no contents).

--- a/crates/client/tests/ws_connector.rs
+++ b/crates/client/tests/ws_connector.rs
@@ -1,6 +1,6 @@
 use futures_util::StreamExt;
 use ghostwriter_client::remote::WsClient;
-use ghostwriter_proto::{Envelope, Hello, MessageType, RequestFrame, Resize, decode};
+use ghostwriter_proto::{Auth, Envelope, Hello, MessageType, RequestFrame, Resize, decode};
 use tokio::net::TcpListener;
 use tokio_tungstenite::accept_async;
 
@@ -36,8 +36,42 @@ async fn hello_and_request_frame_on_connect_and_resize() {
     });
 
     let url = format!("ws://{addr}");
-    let mut client = WsClient::connect(&url, 80, 24).await.unwrap();
+    let mut client = WsClient::connect(&url, 80, 24, None).await.unwrap();
     client.resize(100, 50).await.unwrap();
+
+    server.await.unwrap();
+}
+
+#[tokio::test]
+async fn sends_auth_when_secret_provided() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let mut ws = accept_async(stream).await.unwrap();
+
+        // Hello
+        let msg = ws.next().await.unwrap().unwrap();
+        let env: Envelope<Hello> = decode(&msg.into_data()).unwrap();
+        assert_eq!(env.ty, MessageType::Hello);
+
+        // Auth
+        let msg = ws.next().await.unwrap().unwrap();
+        let env: Envelope<Auth> = decode(&msg.into_data()).unwrap();
+        assert_eq!(env.ty, MessageType::Auth);
+        assert_eq!(env.data.secret, "s3cr3t");
+
+        // RequestFrame (initial)
+        let msg = ws.next().await.unwrap().unwrap();
+        let env: Envelope<RequestFrame> = decode(&msg.into_data()).unwrap();
+        assert_eq!(env.data.reason, "initial");
+    });
+
+    let url = format!("ws://{addr}");
+    let _client = WsClient::connect(&url, 80, 24, Some("s3cr3t"))
+        .await
+        .unwrap();
 
     server.await.unwrap();
 }

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -61,6 +61,11 @@ pub struct Hello {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Auth {
+    pub secret: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Resize {
     pub cols: u16,
     pub rows: u16,
@@ -176,6 +181,18 @@ mod tests {
         assert_eq!(decoded.v, PROTOCOL_VERSION);
         assert_eq!(decoded.ty, MessageType::Hello);
         assert_eq!(decoded.data, hello);
+    }
+
+    #[test]
+    fn auth_roundtrip() {
+        let auth = Auth {
+            secret: "topsecret".into(),
+        };
+        let env = Envelope::new(MessageType::Auth, auth.clone());
+        let encoded = encode(&env).expect("encode");
+        let decoded: Envelope<Auth> = decode(&encoded).expect("decode");
+        assert_eq!(decoded.ty, MessageType::Auth);
+        assert_eq!(decoded.data, auth);
     }
 
     #[test]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -9,6 +9,8 @@ ghostwriter-proto = { path = "../proto" }
 tokio = { version = "1.47.1", features = ["full"] }
 tokio-tungstenite = { version = "0.27.0", features = ["rustls-tls-native-roots"] }
 futures-util = "0.3.31"
+argon2 = { version = "0.5", features = ["std"] }
 
 [dev-dependencies]
 tempfile = "3.10.1"
+rand_core = { version = "0.6", features = ["std"] }

--- a/crates/server/src/auth.rs
+++ b/crates/server/src/auth.rs
@@ -1,0 +1,33 @@
+use std::{fs, io, path::Path};
+
+/// Load the Argon2 hash from `path`. Returns `Ok(None)` if the file does not
+/// exist.
+pub fn load_hash<P: AsRef<Path>>(path: P) -> io::Result<Option<String>> {
+    match fs::read_to_string(path) {
+        Ok(s) => Ok(Some(s.trim().to_string())),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn loads_existing_hash() {
+        let mut file = NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut file, b"hash").unwrap();
+        let path = file.path();
+        let loaded = load_hash(path).unwrap();
+        assert_eq!(loaded, Some("hash".to_string()));
+    }
+
+    #[test]
+    fn missing_file_returns_none() {
+        let path = Path::new("nonexistent");
+        let loaded = load_hash(path).unwrap();
+        assert_eq!(loaded, None);
+    }
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod acceptor;
+pub mod auth;
 pub mod session;
 
 /// Server entry point.

--- a/crates/server/tests/ws_acceptor.rs
+++ b/crates/server/tests/ws_acceptor.rs
@@ -1,6 +1,9 @@
-use futures_util::StreamExt;
-use ghostwriter_proto::{Envelope, ErrorCode, ErrorMsg, MessageType, decode};
+use argon2::password_hash::SaltString;
+use argon2::{Argon2, PasswordHasher};
+use futures_util::{SinkExt, StreamExt};
+use ghostwriter_proto::{Auth, Envelope, ErrorCode, ErrorMsg, Hello, MessageType, decode, encode};
 use ghostwriter_server::acceptor;
+use rand_core::OsRng;
 use tokio::net::TcpListener;
 use tokio_tungstenite::tungstenite::Message;
 
@@ -9,7 +12,7 @@ async fn rejects_second_client_with_busy() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let server = tokio::spawn(async move {
-        acceptor::run_tcp(listener).await.unwrap();
+        acceptor::run_tcp(listener, None).await.unwrap();
     });
 
     let (mut ws1, _) = tokio_tungstenite::connect_async(format!("ws://{addr}"))
@@ -39,5 +42,113 @@ async fn rejects_second_client_with_busy() {
         .unwrap();
     ws3.close(None).await.unwrap();
 
+    server.abort();
+}
+
+#[tokio::test]
+async fn rejects_invalid_auth() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let salt = SaltString::generate(&mut OsRng);
+    let argon2 = Argon2::default();
+    let hash = argon2
+        .hash_password("s3cr3t".as_bytes(), &salt)
+        .unwrap()
+        .to_string();
+
+    let server = tokio::spawn(async move {
+        acceptor::run_tcp(listener, Some(hash)).await.unwrap();
+    });
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}"))
+        .await
+        .unwrap();
+
+    // Send Hello
+    let hello = Hello {
+        client_name: "c".into(),
+        client_ver: "1".into(),
+        cols: 80,
+        rows: 24,
+        truecolor: true,
+    };
+    let env = Envelope::new(MessageType::Hello, hello);
+    ws.send(Message::Binary(encode(&env).unwrap().into()))
+        .await
+        .unwrap();
+
+    // Send wrong Auth
+    let auth = Auth {
+        secret: "bad".into(),
+    };
+    let env = Envelope::new(MessageType::Auth, auth);
+    ws.send(Message::Binary(encode(&env).unwrap().into()))
+        .await
+        .unwrap();
+
+    match ws.next().await.unwrap().unwrap() {
+        Message::Binary(data) => {
+            let env: Envelope<ErrorMsg> = decode(&data).unwrap();
+            assert_eq!(env.data.code, ErrorCode::Unauthorized);
+        }
+        other => panic!("unexpected: {other:?}"),
+    }
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn accepts_valid_auth() {
+    use tokio::time::{Duration, timeout};
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let salt = SaltString::generate(&mut OsRng);
+    let argon2 = Argon2::default();
+    let hash = argon2
+        .hash_password("s3cr3t".as_bytes(), &salt)
+        .unwrap()
+        .to_string();
+
+    let server = tokio::spawn(async move {
+        acceptor::run_tcp(listener, Some(hash)).await.unwrap();
+    });
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}"))
+        .await
+        .unwrap();
+
+    // Hello
+    let hello = Hello {
+        client_name: "c".into(),
+        client_ver: "1".into(),
+        cols: 80,
+        rows: 24,
+        truecolor: true,
+    };
+    let env = Envelope::new(MessageType::Hello, hello);
+    ws.send(Message::Binary(encode(&env).unwrap().into()))
+        .await
+        .unwrap();
+
+    // Correct Auth
+    let auth = Auth {
+        secret: "s3cr3t".into(),
+    };
+    let env = Envelope::new(MessageType::Auth, auth);
+    ws.send(Message::Binary(encode(&env).unwrap().into()))
+        .await
+        .unwrap();
+
+    // Ensure no error is sent within 100ms
+    assert!(
+        timeout(Duration::from_millis(100), ws.next())
+            .await
+            .is_err()
+    );
+
+    ws.close(None).await.unwrap();
     server.abort();
 }


### PR DESCRIPTION
## Summary
- add Auth message to protocol
- support optional shared-secret authentication in client and server
- load Argon2-hashed secrets from file

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features --locked`


------
https://chatgpt.com/codex/tasks/task_e_689b3d5716cc83328ff8269741420475