### PR TITLE
feat: add audit logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,6 +643,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-tungstenite",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1467,6 +1469,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.142"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1778,6 +1792,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,12 +1811,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.98"
 clap = { version = "4.5.43", features = ["derive", "env"] }
 tokio = { version = "1.47.1", features = ["full"] }
 tracing = "0.1.41"
-tracing-subscriber = { version = "0.3.19", features = ["fmt", "env-filter"] }
+tracing-subscriber = { version = "0.3.19", features = ["fmt", "env-filter", "json"] }
 ghostwriter-server = { path = "crates/server" }
 ghostwriter-client = { path = "crates/client" }
 

--- a/TODO.md
+++ b/TODO.md
@@ -32,7 +32,7 @@
 * [x] **Auth (optional)** — Argon2id storage file, login flow, shared-secret env/CLI.
 * [x] **Rate limiting** — 3/min per peer; error `RateLimit`; backoff hints.
 * [x] **Session lifecycle** — clean shutdown, lock release, save on exit; server banner/status.
-* [ ] **Logging & audit** — JSON logs + audit of open/save/rename/delete/auth (no contents).
+* [x] **Logging & audit** — JSON logs + audit of open/save/rename/delete/auth (no contents).
 * [ ] **Acceptance pack #2** — second client blocked; wrong password thrice ⇒ rate-limit.
 
 ---

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -10,7 +10,9 @@ tokio = { version = "1.47.1", features = ["full"] }
 tokio-tungstenite = { version = "0.27.0", features = ["rustls-tls-native-roots"] }
 futures-util = "0.3.31"
 argon2 = { version = "0.5", features = ["std"] }
+tracing = "0.1.41"
 
 [dev-dependencies]
 tempfile = "3.10.1"
 rand_core = { version = "0.6", features = ["std"] }
+tracing-subscriber = { version = "0.3.19", features = ["fmt", "env-filter", "json"] }

--- a/crates/server/src/acceptor.rs
+++ b/crates/server/src/acceptor.rs
@@ -7,6 +7,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use crate::audit;
 use argon2::{Argon2, PasswordHash, PasswordVerifier};
 use futures_util::{SinkExt, StreamExt};
 use ghostwriter_proto::{Auth, Envelope, ErrorCode, ErrorMsg, Hello, MessageType, decode, encode};
@@ -123,6 +124,7 @@ async fn handle_connection<S>(
                     .verify_password(env.data.secret.as_bytes(), &parsed)
                     .is_err()
                 {
+                    audit::log_auth("fail");
                     let env = Envelope::new(
                         MessageType::Error,
                         ErrorMsg {
@@ -136,6 +138,8 @@ async fn handle_connection<S>(
                     let _ = ws.close(None).await;
                     active.store(false, Ordering::SeqCst);
                     return;
+                } else {
+                    audit::log_auth("success");
                 }
             }
             _ => {

--- a/crates/server/src/audit.rs
+++ b/crates/server/src/audit.rs
@@ -1,0 +1,74 @@
+use std::path::Path;
+
+/// Log an audit event for opening a file.
+pub fn log_open<P: AsRef<Path>>(path: P) {
+    tracing::info!(target: "audit", op = "open", path = %path.as_ref().display());
+}
+
+/// Log an audit event for saving a file.
+pub fn log_save<P: AsRef<Path>>(path: P, result: &str) {
+    tracing::info!(target: "audit", op = "save", path = %path.as_ref().display(), result);
+}
+
+/// Log an audit event for renaming a file.
+pub fn log_rename<P: AsRef<Path>>(from: P, to: P, result: &str) {
+    tracing::info!(target: "audit", op = "rename", from = %from.as_ref().display(), to = %to.as_ref().display(), result);
+}
+
+/// Log an audit event for deleting a file.
+pub fn log_delete<P: AsRef<Path>>(path: P, result: &str) {
+    tracing::info!(target: "audit", op = "delete", path = %path.as_ref().display(), result);
+}
+
+/// Log an authentication result.
+pub fn log_auth(result: &str) {
+    tracing::info!(target: "audit", op = "auth", result);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{self, Write};
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::fmt::MakeWriter;
+
+    #[derive(Clone)]
+    struct Buf(Arc<Mutex<Vec<u8>>>);
+
+    impl<'a> MakeWriter<'a> for Buf {
+        type Writer = BufGuard;
+        fn make_writer(&'a self) -> Self::Writer {
+            BufGuard(self.0.clone())
+        }
+    }
+
+    struct BufGuard(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for BufGuard {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().write(buf)
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            self.0.lock().unwrap().flush()
+        }
+    }
+
+    #[test]
+    fn logs_open_and_save() {
+        let buf = Buf(Arc::new(Mutex::new(Vec::new())));
+        let subscriber = tracing_subscriber::fmt()
+            .json()
+            .with_writer(buf.clone())
+            .finish();
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        log_open("/tmp/test");
+        log_save("/tmp/test", "ok");
+
+        let logs = String::from_utf8(buf.0.lock().unwrap().clone()).unwrap();
+        assert!(logs.contains("\"op\":\"open\""));
+        assert!(logs.contains("\"op\":\"save\""));
+
+        drop(_guard);
+    }
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod acceptor;
+pub mod audit;
 pub mod auth;
 pub mod session;
 

--- a/crates/server/src/session.rs
+++ b/crates/server/src/session.rs
@@ -5,6 +5,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use crate::audit;
 use ghostwriter_core::{Debouncer, RopeBuffer, ViewportParams, compose_hex, compose_viewport};
 use ghostwriter_proto::Frame;
 use tokio::sync::mpsc;
@@ -55,7 +56,9 @@ impl Session {
         } else {
             None
         };
-        Ok(Self::spawn_inner(buffer, hex_bytes, path, cols, rows))
+        let handle = Self::spawn_inner(buffer, hex_bytes, path.clone(), cols, rows);
+        audit::log_open(&path);
+        Ok(handle)
     }
 
     /// Spawn a session actor with the provided buffer and viewport size.
@@ -111,7 +114,8 @@ impl Session {
                         let path = self.path.clone();
                         self.debounce.call(move || {
                             if let Ok(buf) = buffer.lock() {
-                                let _ = buf.save_to(&path);
+                                let res = buf.save_to(&path);
+                                audit::log_save(&path, if res.is_ok() { "ok" } else { "err" });
                             }
                         });
                         self.emit_frame(&tx).await;
@@ -124,7 +128,8 @@ impl Session {
                     if self.hex_bytes.is_none()
                         && let Ok(buf) = self.buffer.lock()
                     {
-                        let _ = buf.save_to(&self.path);
+                        let res = buf.save_to(&self.path);
+                        audit::log_save(&self.path, if res.is_ok() { "ok" } else { "err" });
                     }
                 }
             }
@@ -133,7 +138,8 @@ impl Session {
         if self.hex_bytes.is_none()
             && let Ok(buf) = self.buffer.lock()
         {
-            let _ = buf.save_to(&self.path);
+            let res = buf.save_to(&self.path);
+            audit::log_save(&self.path, if res.is_ok() { "ok" } else { "err" });
         }
     }
 

--- a/crates/server/tests/ws_acceptor.rs
+++ b/crates/server/tests/ws_acceptor.rs
@@ -205,3 +205,88 @@ async fn rate_limits_connections() {
 
     server.abort();
 }
+
+#[tokio::test(flavor = "current_thread")]
+async fn logs_auth_attempts() {
+    use std::io::{self, Write};
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::fmt::MakeWriter;
+
+    #[derive(Clone)]
+    struct Buf(Arc<Mutex<Vec<u8>>>);
+
+    impl<'a> MakeWriter<'a> for Buf {
+        type Writer = BufGuard;
+        fn make_writer(&'a self) -> Self::Writer {
+            BufGuard(self.0.clone())
+        }
+    }
+
+    struct BufGuard(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for BufGuard {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().write(buf)
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            self.0.lock().unwrap().flush()
+        }
+    }
+
+    let buf = Buf(Arc::new(Mutex::new(Vec::new())));
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_writer(buf.clone())
+        .finish();
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let salt = SaltString::generate(&mut OsRng);
+        let argon2 = Argon2::default();
+        let hash = argon2
+            .hash_password("s3cr3t".as_bytes(), &salt)
+            .unwrap()
+            .to_string();
+
+        let server = tokio::spawn(async move {
+            acceptor::run_tcp(listener, Some(hash)).await.unwrap();
+        });
+
+        // Fail auth
+        let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{addr}"))
+            .await
+            .unwrap();
+
+        let hello = Hello {
+            client_name: "c".into(),
+            client_ver: "1".into(),
+            cols: 80,
+            rows: 24,
+            truecolor: true,
+        };
+        let env = Envelope::new(MessageType::Hello, hello);
+        ws.send(Message::Binary(encode(&env).unwrap().into()))
+            .await
+            .unwrap();
+
+        let auth = Auth {
+            secret: "bad".into(),
+        };
+        let env = Envelope::new(MessageType::Auth, auth);
+        ws.send(Message::Binary(encode(&env).unwrap().into()))
+            .await
+            .unwrap();
+
+        let _ = ws.next().await; // receive error
+        ws.close(None).await.unwrap();
+        server.abort();
+
+        let logs = String::from_utf8(buf.0.lock().unwrap().clone()).unwrap();
+        assert!(logs.contains("\"op\":\"auth\""));
+        assert!(logs.contains("\"result\":\"fail\""));
+    }
+    drop(_guard);
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -40,7 +40,11 @@ pub fn init_logging() {
     use tracing_subscriber::{EnvFilter, fmt};
 
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-    let subscriber = fmt().with_env_filter(filter).finish();
+    let subscriber = fmt()
+        .with_env_filter(filter)
+        .json()
+        .flatten_event(true)
+        .finish();
     let _ = tracing::subscriber::set_global_default(subscriber);
 }
 


### PR DESCRIPTION
## Summary
- switch to JSON tracing formatter
- introduce audit helpers for auth and file operations
- record auth and file events in server components

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features --locked`


------
https://chatgpt.com/codex/tasks/task_e_689c5abb46908332ac55583142030b85